### PR TITLE
GLOBAL: Unbrick

### DIFF
--- a/cmd/txt-suite/README.md
+++ b/cmd/txt-suite/README.md
@@ -119,8 +119,8 @@ package main
 import (
 	"log"
 
-	"github.com/9elements/txt-suite/pkg/hwapi"
-	"github.com/9elements/txt-suite/pkg/test"
+	"github.com/9elements/converged-security-suite/pkg/hwapi"
+	"github.com/9elements/converged-security-suite/pkg/test"
 )
 
 func main() {
@@ -147,8 +147,8 @@ package main
 import (
 	"log"
 
-	"github.com/9elements/txt-suite/pkg/hwapi"
-	"github.com/9elements/txt-suite/pkg/test"
+	"github.com/9elements/converged-security-suite/pkg/hwapi"
+	"github.com/9elements/converged-security-suite/pkg/test"
 )
 
 func main() {

--- a/cmd/txt-suite/cmd.go
+++ b/cmd/txt-suite/cmd.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/9elements/txt-suite/pkg/test"
+	"github.com/9elements/converged-security-suite/pkg/test"
 )
 
 var testno = flag.String("t", "", "Select test number 1 - 50. e.g.: -t=1,2,3,4,...")

--- a/cmd/txt-suite/main.go
+++ b/cmd/txt-suite/main.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"sort"
 
-	"github.com/9elements/txt-suite/pkg/hwapi"
-	"github.com/9elements/txt-suite/pkg/test"
+	"github.com/9elements/converged-security-suite/pkg/hwapi"
+	"github.com/9elements/converged-security-suite/pkg/test"
 	a "github.com/logrusorgru/aurora"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/9elements/txt-suite
+module github.com/9elements/converged-security-suite
 
 go 1.11
 

--- a/pkg/test/acpi.go
+++ b/pkg/test/acpi.go
@@ -3,7 +3,7 @@ package test
 import (
 	"fmt"
 
-	"github.com/9elements/txt-suite/pkg/hwapi"
+	"github.com/9elements/converged-security-suite/pkg/hwapi"
 )
 
 func notImplemented(txtAPI hwapi.APIInterfaces) (bool, error, error) {

--- a/pkg/test/cpu.go
+++ b/pkg/test/cpu.go
@@ -1,8 +1,8 @@
 package test
 
 import (
-	"github.com/9elements/txt-suite/pkg/hwapi"
-	"github.com/9elements/txt-suite/pkg/tools"
+	"github.com/9elements/converged-security-suite/pkg/hwapi"
+	"github.com/9elements/converged-security-suite/pkg/tools"
 	"github.com/intel-go/cpuid"
 
 	"fmt"

--- a/pkg/test/fit.go
+++ b/pkg/test/fit.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/9elements/txt-suite/pkg/hwapi"
-	"github.com/9elements/txt-suite/pkg/tools"
+	"github.com/9elements/converged-security-suite/pkg/hwapi"
+	"github.com/9elements/converged-security-suite/pkg/tools"
 )
 
 // FITSize 16MiB

--- a/pkg/test/memory.go
+++ b/pkg/test/memory.go
@@ -3,8 +3,8 @@ package test
 import (
 	"fmt"
 
-	"github.com/9elements/txt-suite/pkg/hwapi"
-	"github.com/9elements/txt-suite/pkg/tools"
+	"github.com/9elements/converged-security-suite/pkg/hwapi"
+	"github.com/9elements/converged-security-suite/pkg/tools"
 )
 
 var (

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -3,7 +3,7 @@ package test
 import (
 	"fmt"
 
-	"github.com/9elements/txt-suite/pkg/hwapi"
+	"github.com/9elements/converged-security-suite/pkg/hwapi"
 )
 
 const (

--- a/pkg/test/test_test.go
+++ b/pkg/test/test_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/9elements/txt-suite/pkg/hwapi"
+	"github.com/9elements/converged-security-suite/pkg/hwapi"
 )
 
 func TestTest_Run(t *testing.T) {

--- a/pkg/test/tpm.go
+++ b/pkg/test/tpm.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/9elements/converged-security-suite/pkg/hwapi"
+	"github.com/9elements/converged-security-suite/pkg/tools"
 	tss "github.com/9elements/go-tss"
-	"github.com/9elements/txt-suite/pkg/hwapi"
-	"github.com/9elements/txt-suite/pkg/tools"
 	tpm1 "github.com/google/go-tpm/tpm"
 	tpm2 "github.com/google/go-tpm/tpm2"
 )

--- a/pkg/tools/txt.go
+++ b/pkg/tools/txt.go
@@ -5,7 +5,7 @@ import (
 	"encoding/binary"
 	"io"
 
-	"github.com/9elements/txt-suite/pkg/hwapi"
+	"github.com/9elements/converged-security-suite/pkg/hwapi"
 )
 
 const (

--- a/pkg/tools/txt_test.go
+++ b/pkg/tools/txt_test.go
@@ -3,7 +3,7 @@ package tools
 import (
 	"testing"
 
-	"github.com/9elements/txt-suite/pkg/hwapi"
+	"github.com/9elements/converged-security-suite/pkg/hwapi"
 )
 
 func TestTXT(t *testing.T) {


### PR DESCRIPTION
Rename packages to match new name as original package doesn't exists any more.

Signed-off-by: Patrick Rudolph <patrick.rudolph@9elements.com>