### PR TITLE
Add TxtPrivateReservedInE820 test. 

### DIFF
--- a/cmd/txt-suite/TESTPLAN.md
+++ b/cmd/txt-suite/TESTPLAN.md
@@ -49,21 +49,22 @@ Id | Test | Implemented | Document | Chapter
 46 | SINIT ACM supports used TPM                      | :white_check_mark:     | Document 315168-016          | 4.1.4 Supported Platform Configurations                 
 47 | TXT memory ranges valid                          | :white_check_mark:     | Document 315168-016          | B.1                                                     
 48 | TXT public area reserved in e820                 | :white_check_mark:     | Document 558294 Revision 2.0 | 5.5.3 Intel TXT Public Space                            
-49 | TXT memory reserved in e820                      | :white_check_mark:     | Document 558294 Revision 2.0 | 5.5.4 TPM Decode Area                                   
-50 | MMIO TPMDecode space reserved in e820            | :white_check_mark:     | Document 558294 Revision 2.0 | 5.5.4 TPM Decode Area                                   
-51 | TXT memory in a DMA protected range              | :white_check_mark:     | Document 315168-016          | 1.11.1 DMA Protected Range (DPR)                        
-52 | TXT DPR register locked                          | :white_check_mark:     | Document 315168-016          | 1.11.1 DMA Protected Range (DPR)                        
-53 | CPU DPR equals hostbridge DPR                    | :white_check_mark:     | Document 315168-016          | B 1.15 TXT.DPR – DMA Protected Range                    
-54 | CPU hostbridge DPR register locked               | :white_check_mark:     | Document 315168-016          | B 1.15 TXT.DPR – DMA Protected Range                    
-55 | TXT region contains SINIT ACM                    | :white_check_mark:     | Document 315168-016          | B 1.10 TXT.SINIT.BASE – SINIT Base Address              
-56 | SINIT ACM matches chipset                        | :white_check_mark:     | Document 315168-016          | 2.2.3.1 Matching an AC Module to the Platform           
-57 | SINIT ACM matches CPU                            | :white_check_mark:     | Document 315168-016          | 2.2.3.1 Matching an AC Module to the Platform           
-58 | SINIT ACM startup successful                     | :white_check_mark:     |                              |                                                         
-59 | BIOS DATA REGION present                         | :white_check_mark:     | Document 315168-016          | C.2 BIOS Data Format                                    
-60 | BIOS DATA REGION valid                           | :white_check_mark:     | Document 315168-016          | C.2 BIOS Data Format                                    
-61 | CPU supports MTRRs                               | :white_check_mark:     | Document 315168-016          | 2.2.5.1 MTRR Setup Prior to GETSEC[SENTER] Execution    
-62 | CPU supports SMRRs                               | :white_check_mark:     |                              |                                                         
-63 | SMRR covers SMM memory                           | :white_check_mark:     |                              |                                                         
-64 | SMRR protection active                           | :white_check_mark:     |                              |                                                         
-65 | IOMMU/VT-d active                                | :white_check_mark:     | Document 315168-016          | 1.11.2 Protected Memory Regions (PMRs)                  
-66 | TXT server mode enabled                          | :white_check_mark:     |                              |                                                         
+49 | TXT private area reserved in e820                | :white_check_mark:     | Document 558294 Revision 2.0 | 5.5.2 Intel TXT Private Space                           
+50 | TXT memory reserved in e820                      | :white_check_mark:     | Document 558294 Revision 2.0 | 5.5.4 Intel TPM Decode Area                             
+51 | MMIO TPMDecode space reserved in e820            | :white_check_mark:     | Document 558294 Revision 2.0 | 5.5.4 TPM Decode Area                                   
+52 | TXT memory in a DMA protected range              | :white_check_mark:     | Document 315168-016          | 1.11.1 DMA Protected Range (DPR)                        
+53 | TXT DPR register locked                          | :white_check_mark:     | Document 315168-016          | 1.11.1 DMA Protected Range (DPR)                        
+54 | CPU DPR equals hostbridge DPR                    | :white_check_mark:     | Document 315168-016          | B 1.15 TXT.DPR – DMA Protected Range                    
+55 | CPU hostbridge DPR register locked               | :white_check_mark:     | Document 315168-016          | B 1.15 TXT.DPR – DMA Protected Range                    
+56 | TXT region contains SINIT ACM                    | :white_check_mark:     | Document 315168-016          | B 1.10 TXT.SINIT.BASE – SINIT Base Address              
+57 | SINIT ACM matches chipset                        | :white_check_mark:     | Document 315168-016          | 2.2.3.1 Matching an AC Module to the Platform           
+58 | SINIT ACM matches CPU                            | :white_check_mark:     | Document 315168-016          | 2.2.3.1 Matching an AC Module to the Platform           
+59 | SINIT ACM startup successful                     | :white_check_mark:     |                              |                                                         
+60 | BIOS DATA REGION present                         | :white_check_mark:     | Document 315168-016          | C.2 BIOS Data Format                                    
+61 | BIOS DATA REGION valid                           | :white_check_mark:     | Document 315168-016          | C.2 BIOS Data Format                                    
+62 | CPU supports MTRRs                               | :white_check_mark:     | Document 315168-016          | 2.2.5.1 MTRR Setup Prior to GETSEC[SENTER] Execution    
+63 | CPU supports SMRRs                               | :white_check_mark:     |                              |                                                         
+64 | SMRR covers SMM memory                           | :white_check_mark:     |                              |                                                         
+65 | SMRR protection active                           | :white_check_mark:     |                              |                                                         
+66 | IOMMU/VT-d active                                | :white_check_mark:     | Document 315168-016          | 1.11.2 Protected Memory Regions (PMRs)                  
+67 | TXT server mode enabled                          | :white_check_mark:     |                              |                                                         

--- a/pkg/test/memory.go
+++ b/pkg/test/memory.go
@@ -27,13 +27,23 @@ var (
 		SpecificiationTitle:     IntelTXTBGSBIOSSpecificationTitle,
 		SpecificationDocumentID: IntelTXTBGSBIOSSpecificationDocumentID,
 	}
+	testtxtprivateisreserved = Test{
+		Name:                    "TXT private area reserved in e820",
+		Required:                true,
+		function:                TXTPrivateReservedInE820,
+		dependencies:            []*Test{&testtxtmemoryrangevalid},
+		Status:                  Implemented,
+		SpecificationChapter:    "5.5.2 Intel TXT Private Space",
+		SpecificiationTitle:     IntelTXTBGSBIOSSpecificationTitle,
+		SpecificationDocumentID: IntelTXTBGSBIOSSpecificationDocumentID,
+	}
 	testmemoryisreserved = Test{
 		Name:                    "TXT memory reserved in e820",
 		Required:                true,
 		function:                TXTReservedInE820,
 		dependencies:            []*Test{&testtxtmemoryrangevalid},
 		Status:                  Implemented,
-		SpecificationChapter:    "5.5.4 TPM Decode Area",
+		SpecificationChapter:    "5.5.4 Intel TPM Decode Area",
 		SpecificiationTitle:     IntelTXTBGSBIOSSpecificationTitle,
 		SpecificationDocumentID: IntelTXTBGSBIOSSpecificationDocumentID,
 	}
@@ -190,6 +200,7 @@ var (
 	TestsMemory = [...]*Test{
 		&testtxtmemoryrangevalid,
 		&testtxtpublicisreserved,
+		&testtxtprivateisreserved,
 		&testmemoryisreserved,
 		&testtpmdecodereserved,
 		&testtxtmemoryisdpr,
@@ -282,6 +293,18 @@ func TXTPublicReservedInE820(txtAPI hwapi.APIInterfaces) (bool, error, error) {
 	}
 	return true, nil, nil
 
+}
+
+// TXTPrivateReservedInE820 checks if TXTPrivate area is marked reserved in e820 map
+func TXTPrivateReservedInE820(txtAPI hwapi.APIInterfaces) (bool, error, error) {
+	res, err := txtAPI.IsReservedInE820(uint64(tools.TxtPrivateSpace), uint64(tools.TxtPrivateSpace+tools.TxtPrivateSpaceSize))
+	if err != nil {
+		return false, nil, err
+	}
+	if res != true {
+		return false, fmt.Errorf("TXTPrivate area is not marked reserved in e820 map"), nil
+	}
+	return true, nil, nil
 }
 
 // TXTReservedInE820 checks if the HEAP/MSEG/SINIT TXT regions are marked reserved in e820 map.

--- a/pkg/tools/txt.go
+++ b/pkg/tools/txt.go
@@ -11,10 +11,14 @@ import (
 const (
 	// TxtTPMDecode for external use
 	TxtTPMDecode = 0xFED40000
-	// TxtPublicSpace for external use
+	// TxtPublicSpace for external test
 	TxtPublicSpace = 0xFED30000
 	// TxtPublicSpaceSize exports the size of TXTPublicSpace in memory map
-	TxtPublicSpaceSize   = 0x10000
+	TxtPublicSpaceSize = 0x10000
+	// TxtPrivateSpace for external test
+	TxtPrivateSpace = 0xFED20000
+	// TxtPrivateSpaceSize for external test
+	TxtPrivateSpaceSize  = 0x10000
 	txtEsts              = 0x8
 	txtErrorCode         = 0x30
 	txtBootStatus        = 0xa0


### PR DESCRIPTION
Checks if TXT private memory space is reserved in E820 map

Signed-off-by: Christopher Meis <christopher.meis@9elements.com>