### PR TITLE
Make IOMMU/VT-d test nonCritical

### DIFF
--- a/pkg/test/memory.go
+++ b/pkg/test/memory.go
@@ -155,6 +155,7 @@ var (
 		Required:                false,
 		function:                ActiveIOMMU,
 		Status:                  Implemented,
+		NonCritical:             true,
 		SpecificationChapter:    "1.11.2 Protected Memory Regions (PMRs)",
 		SpecificiationTitle:     IntelTXTSpecificationTitle,
 		SpecificationDocumentID: IntelTXTSpecificationDocumentID,


### PR DESCRIPTION
Signed-off-by: Christopher Meis <christopher.meis@9elements.com>