### PR TITLE
Put tboot tests into own command-line arg

### DIFF
--- a/cmd/txt-suite/cmd.go
+++ b/cmd/txt-suite/cmd.go
@@ -18,8 +18,10 @@ var teststomarkdown = flag.Bool("m", false, "Output test implementation state as
 var version = flag.Bool("v", false, "Shows Version, copyright info and license")
 var tpmdev = flag.String("tpm", "", "Select TPM-Path. e.g.: -tpm=/dev/tpmX, with X as number of the TPM module")
 var logpath = flag.String("log", "", "Give a path/filename for test result output in JSON format. e.g.: /path/to/filename.json")
+var all = flag.Bool("all", false, "Run all the tests of the suite")
+var uefiboot = flag.Bool("uefiboot", false, "Test if platform is UEFI boot enabled")
 var txtready = flag.Bool("txtready", false, "Test if platform is TXTReady")
-var legacyboot = flag.Bool("legacyboot", false, "Test if platform is TXT Legacy boot enabled")
+var tboot = flag.Bool("tboot", false, "Test if tboot hypervisor runs correctly")
 
 func flagUsed() bool {
 	return testno != nil

--- a/cmd/txt-suite/main.go
+++ b/cmd/txt-suite/main.go
@@ -118,12 +118,16 @@ func main() {
 		showVersion()
 	} else if *teststomarkdown == true {
 		listTestsAsMarkdown()
+	} else if *all == true {
+		ret = run(getTests())
+	} else if *uefiboot == true {
+		ret = run(test.TestsUEFIBoot)
 	} else if *txtready == true {
 		ret = run(test.TestsTXTReady)
-	} else if *legacyboot == true {
-		ret = run(test.TestsTXTLegacyBoot)
+	} else if *tboot == true {
+		ret = run(test.TestsTBoot)
 	} else {
-		ret = run(getTests())
+		ret = run(test.TestsBIOSBoot)
 	}
 
 	if ret {

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -167,11 +167,10 @@ var TestsTXTReady = []*Test{
 	&testtpmnvramislocked,
 	&testpsindexconfig,
 	&testauxindexconfig,
-	&testpoindexconfig,
 }
 
-// TestsTXTLegacyBoot - Summarizes all test for TXT legacy boot (not CvBG) platforms
-var TestsTXTLegacyBoot = []*Test{
+// TestsBIOSBoot - Summarizes all test for TXT BIOS boot (not CBnT) platforms
+var TestsBIOSBoot = []*Test{
 	// CPU tests
 	&testcheckforintelcpu,
 	&testwaybridgeorlater,
@@ -184,7 +183,6 @@ var TestsTXTLegacyBoot = []*Test{
 	&testtxtregisterslocked,
 	&testia32debuginterfacelockeddisabled,
 	&testibbmeasured,
-	&testibbistrusted,
 
 	// Memory tests
 	&testtxtmemoryrangevalid,
@@ -230,10 +228,91 @@ var TestsTXTLegacyBoot = []*Test{
 	&testtpmnvramislocked,
 	&testpsindexconfig,
 	&testauxindexconfig,
-	&testpoindexconfig,
 	&testpsindexissvalid,
-	&testpoindexissvalid,
 	&testpcr00valid,
+}
+
+// TestsUEFIBoot - Summarizes all test for TXT UEFI boot (not CBnT) platforms
+var TestsUEFIBoot = []*Test{
+	// CPU tests
+	&testcheckforintelcpu,
+	&testwaybridgeorlater,
+	&testcpusupportstxt,
+	&testtxtregisterspaceaccessible,
+	&testsupportssmx,
+	&testsupportvmx,
+	&testia32featurectrl,
+	&testtxtnotdisabled,
+	&testtxtregisterslocked,
+	&testia32debuginterfacelockeddisabled,
+	&testibbmeasured,
+
+	// Memory tests
+	&testtxtmemoryrangevalid,
+	&testmemoryisreserved,
+	&testtxtmemoryisdpr,
+	&testtxtdprislocked,
+	&testhostbridgeDPRcorrect,
+	&testhostbridgeDPRislocked,
+	&testsinitintxt,
+	&testsinitmatcheschipset,
+	&testsinitmatchescpu,
+	&testbiosdataregionpresent,
+	&testbiosdataregionvalid,
+	&testhasmtrr,
+	&testhassmrr,
+	&testvalidsmrr,
+	&testactivesmrr,
+
+	// FIT tests
+	&testfitvectorisset,
+	&testhasfit,
+	&testhasbiosacm,
+	&testhasibb,
+	&testhaslcpTest,
+	&testibbcoversresetvector,
+	&testibbcoversfitvector,
+	&testibbcoversfit,
+	&testnoibboverlap,
+	&testnobiosacmoverlap,
+	&testnobiosacmisbelow4g,
+	&testpolicyallowstxt,
+	&testbiosacmvalid,
+	&testbiosacmsizecorrect,
+	&testbiosacmaligmentcorrect,
+	&testbiosacmmatcheschipset,
+	&testbiosacmmatchescpu,
+
+	// TPM tests
+	&testtpmconnection,
+	&testtpm12present,
+	&testtpm2present,
+	&testtpmispresent,
+	&testtpmnvramislocked,
+	&testpsindexconfig,
+	&testauxindexconfig,
+	&testpsindexissvalid,
+	&testpcr00valid,
+
+	// ACPI tests
+	&testRSDPChecksum,
+	&testMCFGPresent,
+	&testDMARPresent,
+	&testDMARValid,
+	&testMADTPresent,
+	&testMADTValid,
+	&testRSDTPresent,
+	&testRSDTValid,
+	&testXSDTPresent,
+	&testXSDTValid,
+	&testRSDTorXSDTValid,
+}
+
+// TestsTBoot - Summarizes all test for the tboot hypervisor
+var TestsTBoot = []*Test{
+	&testactiveiommu,
+	&testnosiniterrors,
+	&testibbistrusted,
 }
 
 // Run implements the genereal test function and exposes it.


### PR DESCRIPTION
* Introduce default BIOS boot tests
* Introduce UEFI boot tests
* Introduce tboot tests

Signed-off-by: Philipp Deppenwiese <zaolin@das-labor.org>