### PR TITLE
Remove additional DPR tests

### DIFF
--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -189,8 +189,6 @@ var TestsBIOSBoot = []*Test{
 	&testmemoryisreserved,
 	&testtxtmemoryisdpr,
 	&testtxtdprislocked,
-	&testhostbridgeDPRcorrect,
-	&testhostbridgeDPRislocked,
 	&testsinitintxt,
 	&testsinitmatcheschipset,
 	&testsinitmatchescpu,
@@ -252,8 +250,6 @@ var TestsUEFIBoot = []*Test{
 	&testmemoryisreserved,
 	&testtxtmemoryisdpr,
 	&testtxtdprislocked,
-	&testhostbridgeDPRcorrect,
-	&testhostbridgeDPRislocked,
 	&testsinitintxt,
 	&testsinitmatcheschipset,
 	&testsinitmatchescpu,
@@ -313,6 +309,8 @@ var TestsTBoot = []*Test{
 	&testactiveiommu,
 	&testnosiniterrors,
 	&testibbistrusted,
+	&testhostbridgeDPRcorrect,
+	&testhostbridgeDPRislocked,
 }
 
 // Run implements the genereal test function and exposes it.


### PR DESCRIPTION
Get rid of DPR test on the host bridge. Moved to tboot tests

Signed-off-by: Philipp Deppenwiese <zaolin@das-labor.org>