### PR TITLE
Introduce ugly hack to read data from images with reducted structure.

### DIFF
--- a/pkg/intel/metadata/manifest/key/manifest_nocodegen.go
+++ b/pkg/intel/metadata/manifest/key/manifest_nocodegen.go
@@ -12,10 +12,12 @@ import (
 // Print prints the Key Manifest.
 func (m *Manifest) Print() {
 	fmt.Printf("  --Key Manifest--\n")
-	fmt.Printf("\t%v\n", m.StructInfo.PrettyString(1, true))
-	fmt.Printf("\tKeyManifestSignatureOffset: %v\n", m.KeyManifestSignatureOffset)
-	fmt.Printf("\tKMID: %v\n", m.KMID)
-	fmt.Printf("\tPubKeyHashAlg: %v\n", m.PubKeyHashAlg)
+	fmt.Printf("%v\n", m.StructInfo.PrettyString(1, true))
+	fmt.Printf("  KeyManifestSignatureOffset: %v\n", m.KeyManifestSignatureOffset)
+	fmt.Printf("  Revision: %d\n", m.Revision)
+	fmt.Printf("  KMSVN: %v\n", m.KMSVN)
+	fmt.Printf("  KMID: %v\n", m.KMID)
+	fmt.Printf("  PubKeyHashAlg: %v\n\n", m.PubKeyHashAlg)
 	for _, i := range m.Hash {
 		fmt.Printf("%v\n", i.PrettyString(2, true))
 	}


### PR DESCRIPTION
Problem is, that certain images with a reducted structure won't parse.
This "patch" solves the problem in the short term for functionality.

Signed-off-by: Christopher Meis <christopher.meis@9elements.com>