### PR TITLE
Simple heuristic for local TPM version detection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,12 @@ module github.com/9elements/converged-security-suite/v2
 go 1.13
 
 require (
+	github.com/9elements/tpmtool v0.0.0-20191130171819-da1d98c3e72c
 	github.com/alecthomas/kong v0.2.11
 	github.com/creasty/defaults v1.5.1
 	github.com/dsnet/compress v0.0.1 // indirect
 	github.com/dustin/go-humanize v1.0.0
+	github.com/edsrzf/mmap-go v1.0.0
 	github.com/fatih/camelcase v1.0.0
 	github.com/fatih/structtag v1.2.0 // indirect
 	github.com/fearful-symmetry/gomsr v0.0.1
@@ -19,13 +21,14 @@ require (
 	github.com/mholt/archiver v3.1.1+incompatible
 	github.com/nwaples/rardecode v1.1.0 // indirect
 	github.com/pierrec/lz4 v2.6.0+incompatible // indirect
+	github.com/rekby/gpt v0.0.0-20200614112001-7da10aec5566 // indirect
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.2.2
 	github.com/tidwall/pretty v1.0.2
 	github.com/tjfoc/gmsm v1.4.0
 	github.com/ulikunitz/xz v0.5.8 // indirect
 	github.com/xaionaro-go/gosrc v0.0.0-20201124181305-3fdf8476a735
-	github.com/xaionaro-go/unsafetools v0.0.0-20200202162159-021b112c4d30 // indirect
+	github.com/xaionaro-go/unsafetools v0.0.0-20200202162159-021b112c4d30
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	golang.org/x/crypto v0.0.0-20201012173705-84dcc777aaee
 	golang.org/x/sys v0.0.0-20210218155724-8ebf48af031b // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/9elements/tpmtool v0.0.0-20191130171819-da1d98c3e72c h1:xLhLBDXNwzdp4ED693/ads6PZwiq5prM3p36N+uf/yg=
+github.com/9elements/tpmtool v0.0.0-20191130171819-da1d98c3e72c/go.mod h1:+Ooi80+TsyM7mW4cxBW9h78CCMf/dB21LI0ETDuilbQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/kong v0.2.11 h1:RKeJXXWfg9N47RYfMm0+igkxBCTF4bzbneAxaqid0c4=
@@ -31,6 +33,8 @@ github.com/dsnet/compress v0.0.1/go.mod h1:Aw8dCMJ7RioblQeTqt88akK31OvO8Dhf5Jflh
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/edsrzf/mmap-go v1.0.0 h1:CEBF7HpRnUCSJgGUb5h1Gm7e3VkmVDrR8lvWVLtrOFw=
+github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -137,6 +141,8 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/rekby/gpt v0.0.0-20200614112001-7da10aec5566 h1:U4d0m0NdADC5sjaWXeZpDZ/TFvE866u1Js5yP3M3mho=
+github.com/rekby/gpt v0.0.0-20200614112001-7da10aec5566/go.mod h1:scrOqOnnHVKCHENvFw8k9ajCb88uqLQDA4BvuJNJ2ew=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/pkg/tpm/tpm_detection.go
+++ b/pkg/tpm/tpm_detection.go
@@ -1,0 +1,55 @@
+package tpm
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"runtime"
+	"strings"
+)
+
+type DetectedTPM uint8
+
+const (
+	DetectedNoTPM DetectedTPM = iota
+	DetectedTPM12
+	DetectedTPM20
+)
+
+// DetectLocal provides an easy way of TPM detection based on files heuristics
+func DetectLocal() (DetectedTPM, error) {
+	if runtime.GOOS != "linux" {
+		return 0, fmt.Errorf("tpm.DetectLocal is supported for Linux only")
+	}
+
+	_, err := os.Stat("/dev/tpm0")
+	if err != nil {
+		if os.IsNotExist(err) {
+			return DetectedNoTPM, nil
+		}
+		return 0, fmt.Errorf("failed to check existance of /dev/tpm0, err: %v", err)
+	}
+
+	caps, err := ioutil.ReadFile("/sys/class/tpm/tpm0/device/caps")
+	if err != nil {
+		// This file may not exist for TPM2.0
+		if os.IsNotExist(err) {
+			return DetectedTPM20, nil
+		}
+		return 0, fmt.Errorf("failed to check existance of /sys/class/tpm/tpm0/device/caps, err: %v", err)
+	}
+
+	specPrefix := "TCG version: "
+	var tpmVersion string
+	for _, lineBytes := range bytes.Split(caps, []byte{'\n'}) {
+		line := string(lineBytes)
+		if strings.HasPrefix(line, specPrefix) {
+			tpmVersion = line[len(specPrefix):]
+		}
+	}
+	if tpmVersion == "2.0" {
+		return DetectedTPM20, nil
+	}
+	return DetectedTPM12, nil
+}


### PR DESCRIPTION
I noticed that the code I need is located here: https://github.com/9elements/tpmtool/blob/master/pkg/tpm/tpm.go
But it will not work for me for several reasons:
- I do not need to open TPM device + opening TPM device may fail (due to resource broker)
- /sys/class/tpm/tpm0/caps file does not exist for TPM2.0, but the code path will fail if this is the case

So I decided to create a simple package here in order to not get blocked.