### PR TITLE
[breaking] Rewrite bg-prov stitch

### DIFF
--- a/pkg/tools/ifd.go
+++ b/pkg/tools/ifd.go
@@ -8,14 +8,15 @@ import (
 
 // CalcImageOffset returns the offset of a given uefi flash image
 func CalcImageOffset(image []byte, addr uint64) (uint64, error) {
-	off, size, err := getBIOSRegion(image)
+	off, size, err := GetRegion(image, uefi.RegionTypeBIOS)
 	if err != nil {
 		return 0, err
 	}
 	return uint64(off+size) - FourGiB + addr, nil
 }
 
-func getBIOSRegion(image []byte) (uint32, uint32, error) {
+// GetRegion returns offset and size of the given region type.
+func GetRegion(image []byte, regionType uefi.FlashRegionType) (uint32, uint32, error) {
 	if _, err := uefi.FindSignature(image); err != nil {
 		return 0, 0, err
 	}
@@ -23,10 +24,10 @@ func getBIOSRegion(image []byte) (uint32, uint32, error) {
 	if err != nil {
 		return 0, 0, err
 	}
-	if flash.IFD.Region.FlashRegions[uefi.RegionTypeBIOS].Valid() {
-		offset := flash.IFD.Region.FlashRegions[uefi.RegionTypeBIOS].BaseOffset()
-		size := flash.IFD.Region.FlashRegions[uefi.RegionTypeBIOS].EndOffset() - offset
+	if flash.IFD.Region.FlashRegions[regionType].Valid() {
+		offset := flash.IFD.Region.FlashRegions[regionType].BaseOffset()
+		size := flash.IFD.Region.FlashRegions[regionType].EndOffset() - offset
 		return offset, size, nil
 	}
-	return 0, 0, fmt.Errorf("Couldn't find BIOS region")
+	return 0, 0, fmt.Errorf("Couldn't find region %d", regionType)
 }


### PR DESCRIPTION
 * Move args to optional flag for better extensibility
 * Add ability to replace ME region

What used to be

```
bg-prov coreboot.rom acm.bin km.bin bpm.bin
```

becomes

```
bg-prov coreboot.rom --acm=acm.bin --km=km.bin --bpm=bpm.bin
```

Additionally, it is now possible to replace ME with `--me=me.bin`

Verified that `--me=x` produces binary identical to `ifdtool -i ME:x`