### PR TITLE
Suppress fiano warning

### DIFF
--- a/pkg/tools/fiano_suppress_log.go
+++ b/pkg/tools/fiano_suppress_log.go
@@ -1,0 +1,30 @@
+package tools
+
+import (
+	"io"
+	"log"
+	"runtime"
+	"strings"
+)
+
+type noFianoWriter struct {
+	Backend io.Writer
+}
+
+func (w noFianoWriter) Write(b []byte) (int, error) {
+	_, file, _, _ := runtime.Caller(4)
+	if strings.Contains(file, "github.com/linuxboot/fiano") {
+		return len(b), nil
+	}
+
+	return w.Backend.Write(b)
+}
+
+// See: https://github.com/linuxboot/fiano/issues/330
+func suppressFianoLog() func() {
+	origWriter := log.Writer()
+	log.SetOutput(noFianoWriter{Backend: origWriter})
+	return func() {
+		log.SetOutput(origWriter)
+	}
+}

--- a/pkg/tools/ifd.go
+++ b/pkg/tools/ifd.go
@@ -19,17 +19,19 @@ func CalcImageOffset(image []byte, addr uint64) (uint64, error) {
 
 // GetRegion returns offset and size of the given region type.
 func GetRegion(image []byte, regionType uefi.FlashRegionType) (uint32, uint32, error) {
+	defer suppressFianoLog()()
+
 	if _, err := uefi.FindSignature(image); err != nil {
-		return 0, 0, err
+		return 0, 0, fmt.Errorf("count not find the signature: %w", err)
 	}
 	flash, err := uefi.NewFlashImage(image)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, fmt.Errorf("count not initialize a flash image: %w", err)
 	}
 	if flash.IFD.Region.FlashRegions[regionType].Valid() {
 		offset := flash.IFD.Region.FlashRegions[regionType].BaseOffset()
 		size := flash.IFD.Region.FlashRegions[regionType].EndOffset() - offset
 		return offset, size, nil
 	}
-	return 0, 0, fmt.Errorf("Couldn't find region %d", regionType)
+	return 0, 0, fmt.Errorf("could not find region %d", regionType)
 }

--- a/pkg/tools/ifd_test.go
+++ b/pkg/tools/ifd_test.go
@@ -1,0 +1,29 @@
+// +build go1.16
+
+package tools
+
+import (
+	"log"
+	"testing"
+
+	"github.com/9elements/converged-security-suite/v2/testdata/firmware"
+	"github.com/stretchr/testify/require"
+)
+
+type panicWriter struct{}
+
+func (panicWriter) Write(b []byte) (int, error) {
+	panic("PANIC")
+}
+
+// TestCalcImageOffsetNoLogGarbage checks if fiano sends any garbage into `log`.
+// See: https://github.com/linuxboot/fiano/issues/330
+func TestCalcImageOffsetNoLogGarbage(t *testing.T) {
+	log.SetOutput(panicWriter{})
+
+	img, err := firmware.GetTestImage("../../testdata/firmware/coreboot.fd.xz")
+	require.NoError(t, err)
+
+	_, err = CalcImageOffset(img, 1)
+	require.NoError(t, err)
+}

--- a/testdata/firmware/get_image.go
+++ b/testdata/firmware/get_image.go
@@ -3,6 +3,7 @@ package firmware
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 
 	"github.com/ulikunitz/xz"
@@ -19,13 +20,12 @@ func GetTestImage(testImagePath string) ([]byte, error) {
 		return nil, fmt.Errorf("unable to start decompressing file '%s': %w", testImagePath, err)
 	}
 
-	buf := make([]byte, 1<<23)
-	n, err := r.Read(buf)
+	img, err := ioutil.ReadAll(r)
 	if err != io.EOF {
 		if err != nil {
 			return nil, fmt.Errorf("unable to decompress file '%s': %w", testImagePath, err)
 		}
 	}
 
-	return buf[:n], nil
+	return img, nil
 }


### PR DESCRIPTION
Fiano prints logs and this is non-disablable. See https://github.com/linuxboot/fiano/issues/330

In this PR I temporary suppress fiano-related logs when we call `tools.GetRegion`.

`log.SetOutput` uses a mutex, so it should be safe:
```
// SetOutput sets the output destination for the standard logger.
func SetOutput(w io.Writer) {
	std.mu.Lock()
	defer std.mu.Unlock()
	std.out = w
}
```