### PR TITLE
Fix TPM12 attestation flow

### DIFF
--- a/pkg/pcr/get_measurements_pcr0_legacytxtenabled.go
+++ b/pkg/pcr/get_measurements_pcr0_legacytxtenabled.go
@@ -46,7 +46,8 @@ func MeasureACMDate(fitEntries []fit.Entry) (*Measurement, error) {
 
 func MeasureACMDateInPlace(hashAlg manifest.Algorithm, fitEntries []fit.Entry) (*Measurement, error) {
 	m := Measurement{
-		ID: MeasurementIDACMDateInPlace,
+		ID:        MeasurementIDACMDateInPlace,
+		NoHashing: true,
 	}
 
 	var hashSize int

--- a/pkg/pcr/get_measurements_pcr0_legacytxtenabled.go
+++ b/pkg/pcr/get_measurements_pcr0_legacytxtenabled.go
@@ -46,8 +46,7 @@ func MeasureACMDate(fitEntries []fit.Entry) (*Measurement, error) {
 
 func MeasureACMDateInPlace(hashAlg manifest.Algorithm, fitEntries []fit.Entry) (*Measurement, error) {
 	m := Measurement{
-		ID:        MeasurementIDACMDateInPlace,
-		NoHashing: true,
+		ID: MeasurementIDACMDateInPlace,
 	}
 
 	var hashSize int

--- a/pkg/pcr/measurement.go
+++ b/pkg/pcr/measurement.go
@@ -120,9 +120,6 @@ type Measurement struct {
 
 	// Data contains chunks of data to be measured as contiguous sequence of bytes
 	Data DataChunks `json:",omitempty"`
-
-	// NoHashing tells that the data of this measurement should not be hashed and should be treated as hash
-	NoHashing bool
 }
 
 func eventTypePtr(t tpmeventlog.EventType) *tpmeventlog.EventType {
@@ -132,6 +129,11 @@ func eventTypePtr(t tpmeventlog.EventType) *tpmeventlog.EventType {
 // IsFake forces to skip this measurement in real PCR value calculation
 func (m Measurement) IsFake() bool {
 	return m.ID.IsFake()
+}
+
+// NoHash forces to skip hashing of this measurement's data during PCR calculation
+func (m Measurement) NoHash() bool {
+	return m.ID.NoHash()
 }
 
 // MeasureFunc returns the function to be used for the measurement.
@@ -333,7 +335,7 @@ func (s Measurements) Calculate(image []byte, initialValue uint8, hashFunc hash.
 		measurementData := measurement.CompileMeasurableData(image)
 
 		var hashValue []byte
-		if measurement.NoHashing {
+		if measurement.NoHash() {
 			hashValue = measurementData
 		} else {
 			hashFunc.Write(measurementData)

--- a/pkg/pcr/measurement_id.go
+++ b/pkg/pcr/measurement_id.go
@@ -68,6 +68,15 @@ func (id MeasurementID) IsFake() bool {
 	return false
 }
 
+// NoHash forces to skip hashing of this measurement's data during PCR calculation
+func (id MeasurementID) NoHash() bool {
+	switch id {
+	case MeasurementIDACMDateInPlace:
+		return true
+	}
+	return false
+}
+
 // String implements fmt.Stringer
 func (id MeasurementID) String() string {
 	switch id {


### PR DESCRIPTION
Do not calc hash for MeasurementIDACMDateInPlace
Correct usage of predefined TPM in attestation flow detection

Tested internally on TPM1.2 hosts