### PR TITLE
Fix init of options structure in bpm-gen

### DIFF
--- a/cmd/cbnt-prov/cmd.go
+++ b/cmd/cbnt-prov/cmd.go
@@ -129,7 +129,7 @@ type generateBPMCmd struct {
 	IbbSegsize  uint32               `flag optional name:"ibbsegsize" help:"Value for IBB segment structure"`
 	IbbSegFlag  uint16               `flag optional name:"ibbsegflag" help:"Reducted"`
 	// TXT args
-	SintMin           uint8                       `flag optional name:"sintmin" help:"OEM authorized SinitMinSvn value"`
+	SinitMin          uint8                       `flag optional name:"sinitmin" help:"OEM authorized SinitMinSvn value"`
 	TXTFlags          bootpolicy.TXTControlFlags  `flag optional name:"txtflags" help:"TXT Element control flags"`
 	PowerDownInterval bootpolicy.Duration16In5Sec `flag optional name:"powerdowninterval" help:"Duration of Power Down in 5 sec increments"`
 	ACPIBaseOffset    uint16                      `flag optional name:"acpibaseoffset" help:"ACPI IO offset."`
@@ -391,6 +391,8 @@ func (g *generateBPMCmd) Run(ctx *context) error {
 		options = cbnto
 	} else {
 		var cbnto cbnt.Options
+		cbnto.BootPolicyManifest = bootpolicy.NewManifest()
+		cbnto.KeyManifest = key.NewManifest()
 		cbnto.BootPolicyManifest.BPMH.BPMRevision = g.Revision
 		cbnto.BootPolicyManifest.BPMH.BPMSVN = g.SVN
 		cbnto.BootPolicyManifest.BPMH.ACMSVNAuth = g.ACMSVN
@@ -422,7 +424,7 @@ func (g *generateBPMCmd) Run(ctx *context) error {
 		cbnto.BootPolicyManifest.SE = append(cbnto.BootPolicyManifest.SE, *se)
 
 		txt := bootpolicy.NewTXT()
-		txt.SInitMinSVNAuth = g.SintMin
+		txt.SInitMinSVNAuth = g.SinitMin
 		txt.ControlFlags = g.TXTFlags
 		txt.PwrDownInterval = g.PowerDownInterval
 		txt.ACPIBaseOffset = g.ACPIBaseOffset

--- a/pkg/intel/metadata/manifest/bootpolicy/txt.go
+++ b/pkg/intel/metadata/manifest/bootpolicy/txt.go
@@ -13,7 +13,7 @@ type TXT struct {
 	StructInfo      `id:"__TXTS__" version:"0x21" var0:"0" var1:"uint16(s.TotalSize())"`
 	Reserved0       [1]byte          `require:"0" json:"txtReserved0,omitempty"`
 	SetNumber       [1]byte          `require:"0" json:"txtSetNumer,omitempty"`
-	SInitMinSVNAuth uint8            `json:"txtSVN"`
+	SInitMinSVNAuth uint8            `default:"0" json:"txtSVN"`
 	Reserved1       [1]byte          `require:"0" json:"txtReserved1,omitempty"`
 	ControlFlags    TXTControlFlags  `json:"txtFlags"`
 	PwrDownInterval Duration16In5Sec `json:"txtPwrDownInterval"`

--- a/pkg/intel/metadata/manifest/bootpolicy/txt_manifestcodegen.go
+++ b/pkg/intel/metadata/manifest/bootpolicy/txt_manifestcodegen.go
@@ -31,6 +31,8 @@ func NewTXT() *TXT {
 	copy(s.StructInfo.ID[:], []byte(StructureIDTXT))
 	s.StructInfo.Version = 0x21
 	// Set through tag "default":
+	s.SInitMinSVNAuth = 0
+	// Set through tag "default":
 	s.PTTCMOSOffset0 = 126
 	// Set through tag "default":
 	s.PTTCMOSOffset1 = 127


### PR DESCRIPTION
Signed-off-by: Christopher Meis <christopher.meis@9elements.com>