### PR TITLE
New PrintFit in tabular form

### DIFF
--- a/pkg/intel/metadata/fit/table.go
+++ b/pkg/intel/metadata/fit/table.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/9elements/converged-security-suite/v2/pkg/check"
 	"github.com/9elements/converged-security-suite/v2/pkg/intel/metadata/fit/consts"
@@ -20,6 +21,27 @@ func (table Table) GetEntries(firmware []byte) (result []Entry) {
 		result = append(result, headers.GetEntry(firmware))
 	}
 	return
+}
+
+// String prints the fit table in a tabular form
+func (table Table) String() string {
+	var s strings.Builder
+	// PrintFit prints the Firmware Interface Table in a tabular human readable form.
+	s.WriteString("Firmware Interface Table\n")
+	s.WriteString("------------------------\n")
+	fmt.Fprintf(&s, "%-25s | %-20s | %-8s | %-10s | %-15s | %-10s\n", "Type", "Address", "Size", "Version", "Checksum valid", "Checksum")
+	s.WriteString("-----------------------------------------------------------------------------------------------------\n")
+	for _, entry := range table {
+		fmt.Fprintf(&s, "%-25s | %-20s | %-8d | %-10s | %-15v | %-10d\n",
+			entry.Type().String(),
+			entry.Address.String(),
+			entry.Size.Uint32(),
+			entry.Version.String(),
+			entry.IsChecksumValid(),
+			entry.Checksum)
+	}
+	s.WriteString("\n")
+	return s.String()
 }
 
 // First returns the first entry headers with selected entry type

--- a/pkg/provisioning/cbnt/tools.go
+++ b/pkg/provisioning/cbnt/tools.go
@@ -86,27 +86,6 @@ func PrintCBnTStructures(image []byte) error {
 	return nil
 }
 
-// PrintFIT takes a firmware image and prints the Firmware Interface Table
-func PrintFIT(image []byte) error {
-	fitTable, err := fit.GetTable(image)
-	if err != nil {
-		return fmt.Errorf("unable to get FIT: %w", err)
-	}
-	fitEntries := fitTable.GetEntries(image)
-	fmt.Println("----Firmware Interface Table----")
-	fmt.Println()
-	for idx, entry := range fitEntries {
-		if entry.GetType() == fit.EntryTypeSkip || entry.GetType() == fit.EntryTypeFITHeaderEntry {
-			continue
-		}
-		fmt.Printf("Entry %d\n", idx)
-		fmt.Println(entry.GoString())
-		fmt.Println()
-	}
-	fmt.Println()
-	return nil
-}
-
 // ParseFITEntries takes a firmware image and extract Boot policy manifest, key manifest and acm information.
 func ParseFITEntries(image []byte) (bpm *fit.EntryBootPolicyManifestRecord, km *fit.EntryKeyManifestRecord, acm *fit.EntrySACM, err error) {
 	fitTable, err := fit.GetTable(image)


### PR DESCRIPTION
Remove old PrintFIT function
Add new PrintFit function which prints FIT in a tabular form.

Signed-off-by: Christopher Meis <christopher.meis@9elements.com>