### PR TITLE
bugfix(tpmeventlog): Fix EventLog replay on locality 0

### DIFF
--- a/pkg/tpmeventlog/replay.go
+++ b/pkg/tpmeventlog/replay.go
@@ -13,7 +13,7 @@ func ParseLocality(eventData []byte) (uint8, error) {
 	// but here we will add working recipes for specific cases.
 
 	// event.Data example: "StartupLocality\x00\x03"
-	descrWords := bytes.Split(eventData, []byte{0})
+	descrWords := bytes.SplitN(eventData, []byte{0}, 2)
 	switch {
 	case bytes.Compare(descrWords[0], []byte("StartupLocality")) == 0:
 		if len(descrWords) > 0 && len(descrWords[1]) == 1 {


### PR DESCRIPTION
If the locality is `0` then `bytes.Split(eventData, []byte{0})` worked not as expected. Fixing it.