### PR TITLE
feature(pcr): Add fake measurement for ACM

### DIFF
--- a/pkg/pcr/errors.go
+++ b/pkg/pcr/errors.go
@@ -79,3 +79,11 @@ type ErrUnexpectedEventType struct {
 func (err ErrUnexpectedEventType) Error() string {
 	return fmt.Sprintf("unexpected event type, reason: '%s'; event: '%#+v'", err.Reason, err.Event)
 }
+
+// ErrNoSACM means no S-ACM was found.
+type ErrNoSACM struct{}
+
+// Error implements interface `error`.
+func (err ErrNoSACM) Error() string {
+	return fmt.Sprintf("S-ACM not found")
+}

--- a/pkg/pcr/flow.go
+++ b/pkg/pcr/flow.go
@@ -91,14 +91,15 @@ func (f Flow) MeasurementIDs() MeasurementIDs {
 			 13      0               4        4     9069CA78E7450A285173431B3E52C5C25299E473        00000000                                                  <- Separator
 		*/
 		return MeasurementIDs{
-			MeasurementIDInit, // is fake measurement
+			MeasurementIDInit, // is a fake measurement
+			MeasurementIDACM,  // is a fake measurement
 			MeasurementIDPCR0_DATA,
 			MeasurementIDPCDFirmwareVendorVersionData,
-			MeasurementIDPCDFirmwareVendorVersionCode, // is fake measurement
+			MeasurementIDPCDFirmwareVendorVersionCode, // is a fake measurement
 			MeasurementIDDXE,
 			MeasurementIDSeparator,
-			MeasurementIDFITPointer, // is fake measurement
-			MeasurementIDFITHeaders, // is fake measurement
+			MeasurementIDFITPointer, // is a fake measurement
+			MeasurementIDFITHeaders, // is a fake measurement
 		}
 	case FlowIntelLegacyTXTEnabled:
 		// See also:
@@ -108,40 +109,42 @@ func (f Flow) MeasurementIDs() MeasurementIDs {
 		// * https://www.trustedcomputinggroup.org/wp-content/uploads/PC-ClientSpecific_Platform_Profile_for_TPM_2p0_Systems_v21.pdf (Section 9.3.1)
 		// * doc/log/ymm03.txt
 		return MeasurementIDs{
-			MeasurementIDInit, // is fake measurement
+			MeasurementIDInit, // is a fake measurement
+			MeasurementIDACM,  // is a fake measurement
 			MeasurementIDACMDate,
 			MeasurementIDBIOSStartupModule,
 			MeasurementIDSCRTMSeparator,
 			MeasurementIDPCDFirmwareVendorVersionData,
-			MeasurementIDPCDFirmwareVendorVersionCode, // is fake measurement
+			MeasurementIDPCDFirmwareVendorVersionCode, // is a fake measurement
 			MeasurementIDDXE,
 			MeasurementIDSeparator,
-			MeasurementIDFITPointer, // is fake measurement
-			MeasurementIDFITHeaders, // is fake measurement
+			MeasurementIDFITPointer, // is a fake measurement
+			MeasurementIDFITHeaders, // is a fake measurement
 		}
 	case FlowIntelLegacyTXTEnabledTPM12:
 		return MeasurementIDs{
-			MeasurementIDInit, // is fake measurement
+			MeasurementIDInit, // is a fake measurement
+			MeasurementIDACM,  // is a fake measurement
 			MeasurementIDACMDateInPlace,
 			MeasurementIDBIOSStartupModule,
 			MeasurementIDPCDFirmwareVendorVersionData,
-			MeasurementIDPCDFirmwareVendorVersionCode, // is fake measurement
+			MeasurementIDPCDFirmwareVendorVersionCode, // is a fake measurement
 			MeasurementIDDXE,
 			MeasurementIDSeparator,
-			MeasurementIDFITPointer, // is fake measurement
-			MeasurementIDFITHeaders, // is fake measurement
+			MeasurementIDFITPointer, // is a fake measurement
+			MeasurementIDFITHeaders, // is a fake measurement
 		}
 	case FlowIntelLegacyTXTDisabled:
 		return MeasurementIDs{
 			MeasurementIDPCDFirmwareVendorVersionData,
-			MeasurementIDPCDFirmwareVendorVersionCode, // is fake measurement
+			MeasurementIDPCDFirmwareVendorVersionCode, // is a fake measurement
 			MeasurementIDDXE,
 			MeasurementIDSeparator,
 
 			// Also we include as fake measurements the byte ranges which a known
 			// to be necessary to correctly parse the firmware.
-			MeasurementIDFITPointer, // is fake measurement
-			MeasurementIDFITHeaders, // is fake measurement
+			MeasurementIDFITPointer, // is a fake measurement
+			MeasurementIDFITHeaders, // is a fake measurement
 		}
 	}
 	panic(fmt.Sprintf("should not happen: %v", f))

--- a/pkg/pcr/measurement_id.go
+++ b/pkg/pcr/measurement_id.go
@@ -34,6 +34,7 @@ const (
 	MeasurementIDUndefined = MeasurementID(iota)
 	MeasurementIDInit
 	MeasurementIDPCR0_DATA
+	MeasurementIDACM
 	MeasurementIDACMDate
 	MeasurementIDBIOSStartupModule
 	MeasurementIDSCRTMSeparator
@@ -54,6 +55,8 @@ func (id MeasurementID) IsFake() bool {
 	case MeasurementIDUndefined:
 		return true
 	case MeasurementIDInit:
+		return true
+	case MeasurementIDACM:
 		return true
 	case MeasurementIDPCDFirmwareVendorVersionCode:
 		return true
@@ -84,6 +87,8 @@ func (id MeasurementID) String() string {
 		return "undefined"
 	case MeasurementIDInit:
 		return "init"
+	case MeasurementIDACM:
+		return "ACM"
 	case MeasurementIDPCR0_DATA:
 		return "PCR0_DATA"
 	case MeasurementIDACMDate:
@@ -117,6 +122,8 @@ func (id MeasurementID) PCRIDs() []ID {
 	case MeasurementIDInit:
 		return []ID{0}
 	case MeasurementIDPCR0_DATA:
+		return []ID{0}
+	case MeasurementIDACM:
 		return []ID{0}
 	case MeasurementIDACMDate:
 		return []ID{0}
@@ -223,6 +230,10 @@ func (id MeasurementID) MeasureFunc() MeasureFunc {
 	case MeasurementIDPCR0_DATA:
 		return func(config MeasurementConfig, provider DataProvider) (*Measurement, error) {
 			return MeasurePCR0Data(config, provider.FITEntries())
+		}
+	case MeasurementIDACM:
+		return func(config MeasurementConfig, provider DataProvider) (*Measurement, error) {
+			return MeasureACM(provider.FITEntries())
 		}
 	case MeasurementIDACMDate:
 		return func(config MeasurementConfig, provider DataProvider) (*Measurement, error) {


### PR DESCRIPTION
The problem is that a bitflip in ACM causes TXT to disable. Therefore we should at least display these kind of problems to end users (for them be able to understand why TXT is disabled).

So I add the whole "ACM" as a fake measurement (which does not affect PCR0, but being displayed in reports).