### PR TITLE
manifest/key.go: Also print the correct KM hash for SKL/KBL

### DIFF
--- a/pkg/intel/metadata/manifest/key.go
+++ b/pkg/intel/metadata/manifest/key.go
@@ -202,6 +202,11 @@ func (k *Key) PrintKMPubKey(kmAlg Algorithm) error {
 			}
 			hash.Write(buf.Bytes())
 			fmt.Printf("   Key Manifest Pubkey Hash: 0x%x\n", hash.Sum(nil))
+			// On SKL and KBL the exponent is not included in the KM hash
+			buf.Truncate(len(k.Data[4:]))
+			hash.Reset()
+			hash.Write(buf.Bytes())
+			fmt.Printf("   Key Manifest Pubkey Hash (Skylake and Kabylake only): 0x%x\n", hash.Sum(nil))
 		} else {
 			fmt.Printf("   Key Manifest Pubkey Hash: Unsupported Algorithm\n")
 		}


### PR DESCRIPTION
On Intel Skylake and Kabylake the exponent is not included in the KM
hash in the FPF, so also print what that hash would be for those
platforms. Since it is often not possible to detect this at runtime
with just a KM print both hashes. It's then up to the user to use the
correct one.

Signed-off-by: Arthur Heymans <arthur@aheymans.xyz>