### PR TITLE
Remove acpi functions as members of interface structure. 

### DIFF
--- a/pkg/hwapi/iommu.go
+++ b/pkg/hwapi/iommu.go
@@ -96,7 +96,7 @@ type VTdRegisters struct {
 	Reserved12                              uint64 // Reserved for future expansion of Virtual Command Response Register.
 }
 
-func (t TxtAPI) readVTdRegs() (VTdRegisters, error) {
+func readVTdRegs(t APIInterfaces) (VTdRegisters, error) {
 	var regs VTdRegisters
 
 	dir, err := os.Open("/sys/class/iommu/")
@@ -145,7 +145,7 @@ func (t TxtAPI) LookupIOAddress(addr uint64, regs VTdRegisters) ([]uint64, error
 	ttm := (regs.RootTableAddress >> 10) & 3
 
 	if ttm == 0 {
-		return t.lookupIOLegacy(addr, rootTblAddr)
+		return lookupIOLegacy(addr, rootTblAddr, t)
 	} else if ttm == 1 {
 		return lookupIOScalable(addr, rootTblAddr)
 	} else {
@@ -153,7 +153,7 @@ func (t TxtAPI) LookupIOAddress(addr uint64, regs VTdRegisters) ([]uint64, error
 	}
 }
 
-func (t TxtAPI) lookupIOLegacy(addr, rootTblAddr uint64) ([]uint64, error) {
+func lookupIOLegacy(addr, rootTblAddr uint64, t APIInterfaces) ([]uint64, error) {
 	ret := []uint64{}
 
 	for bus := int64(0); bus < 256; bus++ {
@@ -300,7 +300,7 @@ func lookupIOScalable(addr, rootTblAddr uint64) ([]uint64, error) {
 
 // AddressRangesIsDMAProtected returns true if the address is DMA protected by the IOMMU
 func (t TxtAPI) AddressRangesIsDMAProtected(first, end uint64) (bool, error) {
-	regs, err := t.readVTdRegs()
+	regs, err := readVTdRegs(t)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/hwapi/phys_be.go
+++ b/pkg/hwapi/phys_be.go
@@ -1,0 +1,98 @@
+// Copyright 2012-2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !arm,!arm64
+
+package hwapi
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+)
+
+var memPaths = [...]string{"/dev/fmem", "/dev/mem"}
+
+func pathRead(path string, addr int64, data UintN) error {
+	f, err := os.OpenFile(path, os.O_RDONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := f.Seek(addr, io.SeekCurrent); err != nil {
+		return err
+	}
+	return binary.Read(f, binary.BigEndian, data)
+}
+
+func selectDevMem() (string, error) {
+	if len(memPaths) == 0 {
+		return "", fmt.Errorf("Internal error: no /dev/mem device specified")
+	}
+
+	for _, p := range memPaths {
+		if _, err := os.Stat(p); err == nil {
+			return p, nil
+		}
+	}
+
+	return "", fmt.Errorf("No suitable /dev/mem device found. Tried %#v", memPaths)
+}
+
+// ReadPhys reads data from physical memory at address addr. On x86 platforms,
+// this uses the seek+read syscalls.
+func (t TxtAPI) ReadPhys(addr int64, data UintN) error {
+	devMem, err := selectDevMem()
+	if err != nil {
+		return err
+	}
+
+	return pathRead(devMem, addr, data)
+}
+
+// ReadPhysBuf reads data from physical memory at address addr. On x86 platforms,
+// this uses the seek+read syscalls.
+func (t TxtAPI) ReadPhysBuf(addr int64, buf []byte) error {
+	devMem, err := selectDevMem()
+	if err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(devMem, os.O_RDONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := f.Seek(addr, io.SeekCurrent); err != nil {
+		return err
+	}
+	return binary.Read(f, binary.BigEndian, buf)
+}
+
+func pathWrite(path string, addr int64, data UintN) error {
+	f, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := f.Seek(addr, io.SeekCurrent); err != nil {
+		return err
+	}
+	return binary.Write(f, binary.BigEndian, data)
+}
+
+// WritePhys writes data to physical memory at address addr. On x86 platforms, this
+// uses the seek+read syscalls.
+func (t TxtAPI) WritePhys(addr int64, data UintN) error {
+	devMem, err := selectDevMem()
+	if err != nil {
+		return err
+	}
+
+	return pathWrite(devMem, addr, data)
+}

--- a/pkg/hwapi/phys_le.go
+++ b/pkg/hwapi/phys_le.go
@@ -1,0 +1,98 @@
+// Copyright 2012-2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !amd64,!x86
+
+package hwapi
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+)
+
+var memPaths = [...]string{"/dev/fmem", "/dev/mem"}
+
+func pathRead(path string, addr int64, data UintN) error {
+	f, err := os.OpenFile(path, os.O_RDONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := f.Seek(addr, io.SeekCurrent); err != nil {
+		return err
+	}
+	return binary.Read(f, binary.LittleEndian, data)
+}
+
+func selectDevMem() (string, error) {
+	if len(memPaths) == 0 {
+		return "", fmt.Errorf("Internal error: no /dev/mem device specified")
+	}
+
+	for _, p := range memPaths {
+		if _, err := os.Stat(p); err == nil {
+			return p, nil
+		}
+	}
+
+	return "", fmt.Errorf("No suitable /dev/mem device found. Tried %#v", memPaths)
+}
+
+// ReadPhys reads data from physical memory at address addr. On x86 platforms,
+// this uses the seek+read syscalls.
+func (t TxtAPI) ReadPhys(addr int64, data UintN) error {
+	devMem, err := selectDevMem()
+	if err != nil {
+		return err
+	}
+
+	return pathRead(devMem, addr, data)
+}
+
+// ReadPhysBuf reads data from physical memory at address addr. On x86 platforms,
+// this uses the seek+read syscalls.
+func (t TxtAPI) ReadPhysBuf(addr int64, buf []byte) error {
+	devMem, err := selectDevMem()
+	if err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(devMem, os.O_RDONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := f.Seek(addr, io.SeekCurrent); err != nil {
+		return err
+	}
+	return binary.Read(f, binary.LittleEndian, buf)
+}
+
+func pathWrite(path string, addr int64, data UintN) error {
+	f, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := f.Seek(addr, io.SeekCurrent); err != nil {
+		return err
+	}
+	return binary.Write(f, binary.LittleEndian, data)
+}
+
+// WritePhys writes data to physical memory at address addr. On x86 platforms, this
+// uses the seek+read syscalls.
+func (t TxtAPI) WritePhys(addr int64, data UintN) error {
+	devMem, err := selectDevMem()
+	if err != nil {
+		return err
+	}
+
+	return pathWrite(devMem, addr, data)
+}


### PR DESCRIPTION
They were never part of the interface

Signed-off-by: Christopher Meis <christopher.meis@9elements.com>