### PR TITLE
Add Flow.{Platform,CPU}VendorID

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/google/go-tpm v0.3.3-0.20210120190357-1ff48daca32f
 	github.com/google/uuid v1.2.0
 	github.com/intel-go/cpuid v0.0.0-20200819041909-2aa72927c3e2
+	github.com/klauspost/cpuid/v2 v2.0.9
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/linuxboot/cbfs v0.0.0-20210504130259-7e6ab4ccb5aa
 	github.com/linuxboot/fiano v6.0.0-rc.0.20210427094458-991eadf32b6a+incompatible

--- a/go.sum
+++ b/go.sum
@@ -235,6 +235,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
+github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=

--- a/pkg/pcr/flow.go
+++ b/pkg/pcr/flow.go
@@ -3,6 +3,9 @@ package pcr
 import (
 	"fmt"
 	"strings"
+
+	"github.com/9elements/converged-security-suite/v2/pkg/platformid"
+	"github.com/klauspost/cpuid/v2"
 )
 
 // Flow defines which measurements are used to get the final PCR values.
@@ -238,4 +241,27 @@ func (f Flow) ValidateFlow() ValidateFlow {
 	}
 
 	return nil
+}
+
+// PlatformVendorID returns vendor ID of the platform (which combines CPU and
+// RTM).
+func (f Flow) PlatformVendorID() platformid.VendorID {
+	switch f {
+	case FlowIntelCBnT0T,
+		FlowIntelLegacyTXTEnabled,
+		FlowIntelLegacyTXTEnabledTPM12,
+		FlowIntelLegacyTXTDisabled:
+		return platformid.VendorIDIntel
+	case FlowAMDLocality3,
+		FlowAMDLocality0,
+		FlowLegacyAMDLocality3,
+		FlowLegacyAMDLocality0:
+		return platformid.VendorIDAMD
+	}
+	return platformid.VendorIDUndefined
+}
+
+// CPUVendorID returns vendor ID of the CPU.
+func (f Flow) CPUVendorID() cpuid.Vendor {
+	return f.PlatformVendorID().CPUVendorID()
 }

--- a/pkg/platformid/vendor_id.go
+++ b/pkg/platformid/vendor_id.go
@@ -1,0 +1,52 @@
+package platformid
+
+import (
+	"fmt"
+
+	"github.com/klauspost/cpuid/v2"
+)
+
+// VendorID is an unique ID of a platform vendor.
+//
+// It differs from github.com/klauspost/cpuid.Vendor, because cpuid.Vendor
+// defines CPU vendor, while a platform may combine for example
+// Intel and Lattice (and this combination will have an additional ID).
+type VendorID int
+
+const (
+	// VendorIDUndefined is a VendorID reserved for the zero-value only.
+	VendorIDUndefined = VendorID(iota)
+
+	// VendorIDIntel is a vendor ID corresponds to "Intel".
+	VendorIDIntel
+
+	// VendorIDAMD is a vendor ID corresponds to "AMD".
+	VendorIDAMD
+
+	// EndOfVendorID is a limiter for loops to iterate over VendorID-s.
+	EndOfVendorID
+)
+
+// String implements fmt.Stringer.
+func (vid VendorID) String() string {
+	switch vid {
+	case VendorIDUndefined:
+		return "<undefined>"
+	case VendorIDIntel:
+		return "Intel"
+	case VendorIDAMD:
+		return "AMD"
+	}
+	return fmt.Sprintf("unknown_VendorID_%d", vid)
+}
+
+// CPUVendorID return the vendor ID of the CPU used on the platform.
+func (vid VendorID) CPUVendorID() cpuid.Vendor {
+	switch vid {
+	case VendorIDIntel:
+		return cpuid.Intel
+	case VendorIDAMD:
+		return cpuid.AMD
+	}
+	return cpuid.VendorUnknown
+}

--- a/pkg/platformid/vendor_id_test.go
+++ b/pkg/platformid/vendor_id_test.go
@@ -1,0 +1,24 @@
+package platformid
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/klauspost/cpuid/v2"
+)
+
+func TestVendorIDString(t *testing.T) {
+	for vid := VendorIDUndefined; vid < EndOfVendorID; vid++ {
+		if strings.Contains(vid.String(), "unknown") {
+			t.Fatalf("vid %d has no String", vid)
+		}
+	}
+}
+
+func TestVendorIDCPUVendorID(t *testing.T) {
+	for vid := VendorIDUndefined + 1; vid < EndOfVendorID; vid++ {
+		if vid.CPUVendorID() == cpuid.VendorUnknown {
+			t.Fatalf("vid %d has no CPUVendorID", vid)
+		}
+	}
+}


### PR DESCRIPTION
I need to add vendor-specific logic in the internal service, which uses pcr0tool. So I think this is a good place to add the mapping of flows to vendor IDs.