### PR TITLE
Fix BIOS Directory Entry Type attributes parsing

### DIFF
--- a/pkg/amd/manifest/bios_directory_table.go
+++ b/pkg/amd/manifest/bios_directory_table.go
@@ -178,11 +178,11 @@ func ParseBIOSDirectoryTableEntry(r io.Reader) (*BIOSDirectoryTableEntry, uint64
 	if err := readAndCountSize(r, binary.LittleEndian, &flags, &length); err != nil {
 		return nil, 0, err
 	}
-	entry.ResetImage = (flags>>7)&0x1 != 0
-	entry.CopyImage = (flags>>6)&0x1 != 0
-	entry.ReadOnly = (flags>>5)&0x1 != 0
-	entry.Compressed = (flags>>4)&0x1 != 0
-	entry.Instance = flags >> 3
+	entry.ResetImage = flags&0x1 != 0
+	entry.CopyImage = (flags>>1)&0x1 != 0
+	entry.ReadOnly = (flags>>2)&0x1 != 0
+	entry.Compressed = (flags>>3)&0x1 != 0
+	entry.Instance = flags >> 4
 
 	if err := readAndCountSize(r, binary.LittleEndian, &flags, &length); err != nil {
 		return nil, 0, err

--- a/pkg/amd/manifest/bios_directory_table_test.go
+++ b/pkg/amd/manifest/bios_directory_table_test.go
@@ -83,26 +83,36 @@ func TestBiosDirectoryTableParsing(t *testing.T) {
 		t.Fatalf("Result number of entries is incorrect: %d, expected: %d", len(table.Entries), 1)
 	}
 
-	if table.Entries[0].Type != 0x68 {
+	entry := table.Entries[0]
+	if entry.Type != 0x68 {
 		t.Errorf("Table entry [0] type is incorrect: %d, expected: %d", table.Entries[0].Type, 0x68)
 	}
-	if table.Entries[0].ResetImage {
+	if entry.ResetImage {
 		t.Errorf("Table entry [0] reset image is incorrect, expected false")
 	}
-	if table.Entries[0].CopyImage {
+	if entry.CopyImage {
 		t.Errorf("Table entry [0] copy image is incorrect, expected false")
 	}
-	if table.Entries[0].ReadOnly {
+	if entry.ReadOnly {
 		t.Errorf("Table entry [0] read only is incorrect, expected false")
 	}
-	if !table.Entries[0].Compressed {
+	if entry.Compressed {
 		t.Errorf("Table entry [0] compress is incorrect, expected true")
 	}
-	if table.Entries[0].SourceAddress != 0x173000 {
+	if entry.Instance != 1 {
+		t.Errorf("Table entry [0] instance is incorrect, expected 1, got: %d", entry.Instance)
+	}
+	if entry.Subprogram != 1 {
+		t.Errorf("Table entry [0] subprogram is incorrect, expected 1, got: %d", entry.Subprogram)
+	}
+	if entry.RomID != 0 {
+		t.Errorf("Table entry [0] subprogram is incorrect, expected 9, got: %d", entry.RomID)
+	}
+	if entry.SourceAddress != 0x173000 {
 		t.Errorf("Table entry [0] source address is incorrect: %x, expected: 0x173000",
 			table.Entries[0].SourceAddress)
 	}
-	if table.Entries[0].DestinationAddress != 0xffffffffffffffff {
+	if entry.DestinationAddress != 0xffffffffffffffff {
 		t.Errorf("Table entry [0] destination address is incorrect: %x, expected: 0xffffffffffffffff",
 			table.Entries[0].DestinationAddress)
 	}

--- a/pkg/amd/manifest/bios_directory_table_test.go
+++ b/pkg/amd/manifest/bios_directory_table_test.go
@@ -97,7 +97,7 @@ func TestBiosDirectoryTableParsing(t *testing.T) {
 		t.Errorf("Table entry [0] read only is incorrect, expected false")
 	}
 	if entry.Compressed {
-		t.Errorf("Table entry [0] compress is incorrect, expected true")
+		t.Errorf("Table entry [0] compress is incorrect, expected false")
 	}
 	if entry.Instance != 1 {
 		t.Errorf("Table entry [0] instance is incorrect, expected 1, got: %d", entry.Instance)


### PR DESCRIPTION
Noticed the the order of attribute bits parsing is incorrect