### PR TITLE
Fix AMD firmware parsing slice bounds out of range

### DIFF
--- a/pkg/amd/manifest/firmware.go
+++ b/pkg/amd/manifest/firmware.go
@@ -107,7 +107,7 @@ func parsePSPFirmware(firmware Firmware) (*PSPFirmware, error) {
 		efs.BIOSDirectoryTableFamily17hModels60h3FhPointer,
 	}
 	for _, offset := range biosDirectoryOffsets {
-		if offset == 0 {
+		if offset == 0 || int(offset) > len(image) {
 			continue
 		}
 		var length uint64


### PR DESCRIPTION
The offset must be within the size of the image.
