### PR TITLE
AMD manifest: return meaningful errors for structures not found

### DIFF
--- a/pkg/amd/manifest/bios_directory_table.go
+++ b/pkg/amd/manifest/bios_directory_table.go
@@ -127,7 +127,7 @@ func FindBIOSDirectoryTable(image []byte) (*BIOSDirectoryTable, bytes2.Range, er
 		}
 		return table, bytes2.Range{Offset: offset + uint64(idx), Length: bytesRead}, err
 	}
-	return nil, bytes2.Range{}, fmt.Errorf("EmbeddedFirmwareStructure is not found")
+	return nil, bytes2.Range{}, fmt.Errorf("No BIOSDirectoryTable found")
 }
 
 // ParseBIOSDirectoryTable converts input bytes into BIOSDirectoryTable

--- a/pkg/amd/manifest/embedded_firmware_structure.go
+++ b/pkg/amd/manifest/embedded_firmware_structure.go
@@ -54,7 +54,7 @@ func FindEmbeddedFirmwareStructure(firmware Firmware) (*EmbeddedFirmwareStructur
 			return result, bytes2.Range{Offset: offset, Length: length}, err
 		}
 	}
-	return nil, bytes2.Range{}, fmt.Errorf("EmbeddedFirmwareStructure is not found")
+	return nil, bytes2.Range{}, fmt.Errorf("No EmbeddedFirmwareStructure found")
 }
 
 // ParseEmbeddedFirmwareStructure converts input bytes into EmbeddedFirmwareStructure

--- a/pkg/amd/manifest/psp_directory_table.go
+++ b/pkg/amd/manifest/psp_directory_table.go
@@ -106,7 +106,7 @@ func FindPSPDirectoryTable(image []byte) (*PSPDirectoryTable, bytes2.Range, erro
 		return table, bytes2.Range{Offset: offset + uint64(idx), Length: length}, err
 	}
 
-	return nil, bytes2.Range{}, fmt.Errorf("EmbeddedFirmwareStructure is not found")
+	return nil, bytes2.Range{}, fmt.Errorf("No PSPDirectoryTable found")
 }
 
 // ParsePSPDirectoryTable converts input bytes into PSPDirectoryTable


### PR DESCRIPTION
The previous errors were the same for all cases and misleading.
