### PR TITLE
Fix AMD measurements

### DIFF
--- a/pkg/pcr/flow.go
+++ b/pkg/pcr/flow.go
@@ -184,12 +184,16 @@ func (f Flow) MeasurementIDs() MeasurementIDs {
 		}
 	case FlowLegacyAMDLocality0:
 		return MeasurementIDs{
+			MeasurementIDPSPVersion,
+			MeasurementIDBIOSRTMVolume,
 			MeasurementIDPCDFirmwareVendorVersionData,
 			MeasurementIDDXE,
 			MeasurementIDSeparator,
 		}
 	case FlowLegacyAMDLocality3:
 		return MeasurementIDs{
+			MeasurementIDPSPVersion,
+			MeasurementIDBIOSRTMVolume,
 			MeasurementIDPCDFirmwareVendorVersionData,
 			MeasurementIDDXE,
 			MeasurementIDSeparator,

--- a/pkg/pcr/get_measurements_pcr0_amd.go
+++ b/pkg/pcr/get_measurements_pcr0_amd.go
@@ -78,7 +78,7 @@ func MeasureMP0C2PMsgRegisters(regs registers.Registers) (*Measurement, error) {
 
 // MeasurePSPVersion constructs measurement of PSP version
 func MeasurePSPVersion(image []byte, pspDirectoryLevel1, pspDirectoryLevel2 *amd_manifest.PSPDirectoryTable) (*Measurement, error) {
-	for _, pspDirectory := range []*amd_manifest.PSPDirectoryTable{pspDirectoryLevel1, pspDirectoryLevel2} {
+	for _, pspDirectory := range []*amd_manifest.PSPDirectoryTable{pspDirectoryLevel2, pspDirectoryLevel1} {
 		if pspDirectory == nil {
 			continue
 		}
@@ -98,7 +98,7 @@ func MeasurePSPVersion(image []byte, pspDirectoryLevel1, pspDirectoryLevel2 *amd
 
 // MeasureBIOSRTMVolume constructs measurement of BIOS RTM Volume
 func MeasureBIOSRTMVolume(biosDirectoryLevel1, biosDirectoryLevel2 *amd_manifest.BIOSDirectoryTable) (*Measurement, error) {
-	for _, biosDirectory := range []*amd_manifest.BIOSDirectoryTable{biosDirectoryLevel1, biosDirectoryLevel2} {
+	for _, biosDirectory := range []*amd_manifest.BIOSDirectoryTable{biosDirectoryLevel2, biosDirectoryLevel1} {
 		if biosDirectory == nil {
 			continue
 		}
@@ -110,4 +110,11 @@ func MeasureBIOSRTMVolume(biosDirectoryLevel1, biosDirectoryLevel2 *amd_manifest
 		}
 	}
 	return nil, fmt.Errorf("failed to find BIOS RTM Volume entry")
+}
+
+func checkPSPFirmwareFound(pspFirmware *amd_manifest.PSPFirmware) error {
+	if pspFirmware == nil {
+		return fmt.Errorf("PSP firmware is not found")
+	}
+	return nil
 }

--- a/pkg/pcr/measurement_id.go
+++ b/pkg/pcr/measurement_id.go
@@ -373,32 +373,32 @@ func (id MeasurementID) MeasureFunc() MeasureFunc {
 	case MeasurementIDBIOSDirectoryLevel1Header:
 		return func(config MeasurementConfig, provider DataProvider) (*Measurement, error) {
 			pspFirmware := provider.PSPFirmware()
-			if pspFirmware == nil {
-				return nil, fmt.Errorf("PSP firmware is not found")
+			if err := checkPSPFirmwareFound(pspFirmware); err != nil {
+				return nil, err
 			}
 			return MeasureBIOSDirectoryHeader(pspFirmware.BIOSDirectoryLevel1, pspFirmware.BIOSDirectoryLevel1Range)
 		}
 	case MeasurementIDBIOSDirectoryLevel2Header:
 		return func(config MeasurementConfig, provider DataProvider) (*Measurement, error) {
 			pspFirmware := provider.PSPFirmware()
-			if pspFirmware == nil {
-				return nil, fmt.Errorf("PSP firmware is not found")
+			if err := checkPSPFirmwareFound(pspFirmware); err != nil {
+				return nil, err
 			}
 			return MeasureBIOSDirectoryHeader(pspFirmware.BIOSDirectoryLevel2, pspFirmware.BIOSDirectoryLevel2Range)
 		}
 	case MeasurementIDBIOSDirectoryLevel1:
 		return func(config MeasurementConfig, provider DataProvider) (*Measurement, error) {
 			pspFirmware := provider.PSPFirmware()
-			if pspFirmware == nil {
-				return nil, fmt.Errorf("PSP firmware is not found")
+			if err := checkPSPFirmwareFound(pspFirmware); err != nil {
+				return nil, err
 			}
 			return MeasureBIOSDirectoryTable(pspFirmware.BIOSDirectoryLevel1, pspFirmware.BIOSDirectoryLevel1Range)
 		}
 	case MeasurementIDBIOSDirectoryLevel2:
 		return func(config MeasurementConfig, provider DataProvider) (*Measurement, error) {
 			pspFirmware := provider.PSPFirmware()
-			if pspFirmware == nil {
-				return nil, fmt.Errorf("PSP firmware is not found")
+			if err := checkPSPFirmwareFound(pspFirmware); err != nil {
+				return nil, err
 			}
 			return MeasureBIOSDirectoryTable(pspFirmware.BIOSDirectoryLevel2, pspFirmware.BIOSDirectoryLevel2Range)
 		}
@@ -411,8 +411,8 @@ func (id MeasurementID) MeasureFunc() MeasureFunc {
 	case MeasurementIDEmbeddedFirmwareStructure:
 		return func(config MeasurementConfig, provider DataProvider) (*Measurement, error) {
 			pspFirmware := provider.PSPFirmware()
-			if pspFirmware == nil {
-				return nil, fmt.Errorf("PSP firmware is not found")
+			if err := checkPSPFirmwareFound(pspFirmware); err != nil {
+				return nil, err
 			}
 			return NewRangeMeasurement(
 				MeasurementIDEmbeddedFirmwareStructure,
@@ -423,8 +423,8 @@ func (id MeasurementID) MeasureFunc() MeasureFunc {
 	case MeasurementIDPSPVersion:
 		return func(config MeasurementConfig, provider DataProvider) (*Measurement, error) {
 			pspFirmware := provider.PSPFirmware()
-			if pspFirmware == nil {
-				return nil, fmt.Errorf("PSP firmware is not found")
+			if err := checkPSPFirmwareFound(pspFirmware); err != nil {
+				return nil, err
 			}
 			firmware := provider.Firmware()
 			return MeasurePSPVersion(firmware.ImageBytes(), pspFirmware.PSPDirectoryLevel1, pspFirmware.PSPDirectoryLevel2)
@@ -433,8 +433,8 @@ func (id MeasurementID) MeasureFunc() MeasureFunc {
 	case MeasurementIDBIOSRTMVolume:
 		return func(config MeasurementConfig, provider DataProvider) (*Measurement, error) {
 			pspFirmware := provider.PSPFirmware()
-			if pspFirmware == nil {
-				return nil, fmt.Errorf("PSP firmware is not found")
+			if err := checkPSPFirmwareFound(pspFirmware); err != nil {
+				return nil, err
 			}
 			return MeasureBIOSRTMVolume(pspFirmware.BIOSDirectoryLevel1, pspFirmware.BIOSDirectoryLevel2)
 		}


### PR DESCRIPTION
Fix AMD legacy measurements
Find measured items in primary directory (level 2) first, switch to recovery (level 1) if the item was not found