### PR TITLE
Print ACM revision

### DIFF
--- a/pkg/tools/acm.go
+++ b/pkg/tools/acm.go
@@ -70,6 +70,14 @@ type UUID struct {
 	Field5 [6]uint8
 }
 
+// ACMRevision is the version of the ACM module in format <major>.<minor>.<build>
+type ACMRevision [3]uint8
+
+// String implements fmt.Stringer
+func (r ACMRevision) String() string {
+	return fmt.Sprintf("%d.%d.%d", r[0], r[1], r[2])
+}
+
 // ACMInfo holds the metadata extracted from the ACM header
 type ACMInfo struct {
 	UUID                UUID
@@ -81,7 +89,7 @@ type ACMInfo struct {
 	MinMleHeaderVersion uint32
 	TxtCaps             uint32
 	ACMVersion          uint8
-	Reserved            [3]uint8
+	ACMRevision         ACMRevision
 	ProcessorIDList     uint32
 	TPMInfoList         uint32
 }
@@ -398,6 +406,7 @@ func (a *ACM) PrettyPrint() {
 	fmt.Printf("      Min. MLE Header Version: 0x%08x\n", a.Info.MinMleHeaderVersion)
 	fmt.Printf("      Capabilities: 0x%08x\n", a.Info.TxtCaps)
 	fmt.Printf("      ACM Version: %d\n", a.Info.ACMVersion)
+	fmt.Printf("      ACM Revision: %s\n", a.Info.ACMRevision)
 }
 
 //PrettyPrint prints a human readable representation of the Chipsets


### PR DESCRIPTION
```
[xaionaro@void converged-security-suite]$ go run ./cmd/cbnt-prov/ acm-show /tmp/acm.bin
----Authenticated Code Module----

   Module Vendor: Intel
   Module Type: ACM_TYPE_CHIPSET
   Module Subtype: Execute at Reset
   Module Date: 0x20190715
   Module Size: 0x40000 (262144)
   Header Length: 0xa1 (161)
   Header Version: 0
   Chipset ID: 0xb007
   Flags: 0x00
   TXT SVN: 0x00000003
   SE SVN: 0x00000000
   Code Control: 0x00
   Entry Point: 0x00000008:0001361a
   Scratch Size: 0x8f (143)
   --Info Table--
      UUID: ACM_UUID_V3
      Chipset ACM: BIOS
      Version: 6
      Length: 0x30 (48)
      Chipset ID List: 0x4f0
      OS SINIT Data Version: 0x00
      Min. MLE Header Version: 0x00000000
      Capabilities: 0x00000080
      ACM Version: 99
      Revision: 1.3.81
   --Chipset List--
      Entries: 1
      Entry 0:
         Flags: 0x01
         Vendor: 0x8086
         Device: 0xb007
         Revision: 0x01
   --Processor List--
      Entries: 1
      Entry 0:
         FMS: 0x50650
         FMS Maks: 0xfff3ff0
         Platform ID: 0x00
         Platform Mask: 0x00
   --TPM Info List--
      Capabilities:
         External Policy: 6f
      Algorithms: 8
         SHA1
         SHA256
         SHA384
         SHA512
         Alg?<18>
         RSASSA
         ECDSA
         Alg?<27>
```

Reference document:  315168-017