### PR TITLE
add DataChunkIDBIOSStartup4 and DataChunkIDBIOSStartup5

### DIFF
--- a/pkg/pcr/get_measurements_pcr0_legacytxtenabled.go
+++ b/pkg/pcr/get_measurements_pcr0_legacytxtenabled.go
@@ -147,9 +147,13 @@ func MeasureBIOSStartupModule(imageSize uint64, fitEntries []fit.Entry) (*Measur
 			_ = mErr.Add(fitEntry.HeadersErrors...)
 
 			biosSMOffset := fitEntry.Headers.Address.Offset(imageSize)
+			biosStartup, err := DataChunkIDBIOSStartup(uint(len(m.Data)))
+			if err != nil {
+				return nil, err
+			}
 			m.Data = append(m.Data,
 				*NewRangeDataChunk(
-					DataChunkIDBIOSStartup(uint(len(m.Data))),
+					biosStartup,
 					biosSMOffset,
 					uint64(len(fitEntry.DataSegmentBytes)),
 				),

--- a/pkg/pcr/measurement_id.go
+++ b/pkg/pcr/measurement_id.go
@@ -705,6 +705,8 @@ const (
 	DataChunkIDBIOSStartup1
 	DataChunkIDBIOSStartup2
 	DataChunkIDBIOSStartup3
+	DataChunkIDBIOSStartup4
+	DataChunkIDBIOSStartup5
 	DataChunkIDACMPolicyStatus
 	DataChunkIDACMHeaderSVN
 	DataChunkIDACMSignature
@@ -716,18 +718,22 @@ const (
 
 // DataChunkIDBIOSStartup returns DataChunkID corresponding to
 // entryIndex-th BIOS Startup entry (accordingly to FIT).
-func DataChunkIDBIOSStartup(entryIndex uint) DataChunkID {
+func DataChunkIDBIOSStartup(entryIndex uint) (DataChunkID, error) {
 	switch entryIndex {
 	case 0:
-		return DataChunkIDBIOSStartup0
+		return DataChunkIDBIOSStartup0, nil
 	case 1:
-		return DataChunkIDBIOSStartup1
+		return DataChunkIDBIOSStartup1, nil
 	case 2:
-		return DataChunkIDBIOSStartup2
+		return DataChunkIDBIOSStartup2, nil
 	case 3:
-		return DataChunkIDBIOSStartup3
+		return DataChunkIDBIOSStartup3, nil
+	case 4:
+		return DataChunkIDBIOSStartup4, nil
+	case 5:
+		return DataChunkIDBIOSStartup5, nil
 	}
-	panic(fmt.Sprintf("should not happen: %v", entryIndex))
+	return DataChunkIDUndefined, fmt.Errorf("invalid DataChunkIDBIOSStartup: %v", entryIndex)
 }
 
 // String implements fmt.Stringer
@@ -743,6 +749,10 @@ func (id DataChunkID) String() string {
 		return "BIOS_startup_module_2"
 	case DataChunkIDBIOSStartup3:
 		return "BIOS_startup_module_3"
+	case DataChunkIDBIOSStartup4:
+		return "BIOS_startup_module_4"
+	case DataChunkIDBIOSStartup5:
+		return "BIOS_startup_module_5"
 	case DataChunkIDACMPolicyStatus:
 		return "ACM_policy_status"
 	case DataChunkIDACMHeaderSVN:


### PR DESCRIPTION
Right now, we're just adding two additional startup modes
Longer term this would be better to be dynamic, since
according to the specification, there is no limit to the
number of Startup Modules.

From Intel's Documentation:

In order to enable more flexible flash layout, BIOS Init code can be split in multiple BIOS Startup Modules. Each BIOS Startup Module will have one corresponding Type 7 entry. Each Type 7 entry describes address and size of the corresponding BIOS Startup Module.