### PR TITLE
Feature/arch 386

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/9elements/converged-security-suite/v2/testdata/firmware v0.0.0-00010101000000-000000000000
-	github.com/9elements/go-linux-lowlevel-hw v0.0.0-20211215141225-8375dd201aae
+	github.com/9elements/go-linux-lowlevel-hw v0.0.0-20220518111144-a82949f8ff5b
 	github.com/alecthomas/kong v0.2.11
 	github.com/creasty/defaults v1.5.1
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 contrib.go.opencensus.io/exporter/stackdriver v0.13.4/go.mod h1:aXENhDJ1Y4lIg4EUaVTwzvYETVNZk10Pu26tevFKLUc=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/9elements/go-linux-lowlevel-hw v0.0.0-20211215141225-8375dd201aae h1:BsoCEtuZy+s7LuCNcY4iuGI8WaCyF4sCa116q3E/otM=
-github.com/9elements/go-linux-lowlevel-hw v0.0.0-20211215141225-8375dd201aae/go.mod h1:NRv+EGNg4+XO4g9W9BzC/ckMg/5zgLNkRd/Hh09Nxr4=
+github.com/9elements/go-linux-lowlevel-hw v0.0.0-20220518111144-a82949f8ff5b h1:98V5o52v/uFUliAMAvMcol3b5e5JFMVxzj8XGlVHCm8=
+github.com/9elements/go-linux-lowlevel-hw v0.0.0-20220518111144-a82949f8ff5b/go.mod h1:NRv+EGNg4+XO4g9W9BzC/ckMg/5zgLNkRd/Hh09Nxr4=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=

--- a/pkg/uefi/uefi.go
+++ b/pkg/uefi/uefi.go
@@ -91,14 +91,14 @@ func (uefi *UEFI) ImageBytes() []byte {
 // PhysAddrToOffset returns the offset of `physAddr` relatively
 // to the beginning of the firmware.
 func (uefi *UEFI) PhysAddrToOffset(physAddr uint64) uint64 {
-	startAddr := uint64(consts.BasePhysAddr - len(uefi.ImageBytes()))
+	startAddr := uint64(consts.BasePhysAddr) - uint64(len(uefi.ImageBytes()))
 	return physAddr - startAddr
 }
 
 // OffsetToPhysAddr returns the `physAddr` of offset relatively
 // to the beginning of the firmware.
 func (uefi *UEFI) OffsetToPhysAddr(offset uint64) uint64 {
-	startAddr := uint64(consts.BasePhysAddr - len(uefi.ImageBytes()))
+	startAddr := uint64(consts.BasePhysAddr) - uint64(len(uefi.ImageBytes()))
 	return offset + startAddr
 }
 


### PR DESCRIPTION
# Test plan

### before

```
[xaionaro@void converged-security-suite]$ GOARCH=386 go build ./cmd/pcr0tool
# github.com/9elements/converged-security-suite/v2/pkg/uefi
pkg/uefi/uefi.go:94:42: constant 4294967296 overflows int
pkg/uefi/uefi.go:101:42: constant 4294967296 overflows int
# github.com/9elements/go-linux-lowlevel-hw/pkg/hwapi
/home/xaionaro/go-fbcode-3rdparty/pkg/mod/github.com/9elements/go-linux-lowlevel-hw@v0.0.0-20211215141225-8375dd201aae/pkg/hwapi/acpi.go:508:31: cannot use h (type HwAPI) as type LowLevelHardwareInterfaces in argument to GetACPITableSysFS:
	HwAPI does not implement LowLevelHardwareInterfaces (missing ReadPhys method)
/home/xaionaro/go-fbcode-3rdparty/pkg/mod/github.com/9elements/go-linux-lowlevel-hw@v0.0.0-20211215141225-8375dd201aae/pkg/hwapi/acpi.go:510:32: cannot use h (type HwAPI) as type LowLevelHardwareInterfaces in argument to GetACPITableDevMem:
	HwAPI does not implement LowLevelHardwareInterfaces (missing ReadPhys method)
/home/xaionaro/go-fbcode-3rdparty/pkg/mod/github.com/9elements/go-linux-lowlevel-hw@v0.0.0-20211215141225-8375dd201aae/pkg/hwapi/api.go:56:14: cannot use HwAPI{} (type HwAPI) as type LowLevelHardwareInterfaces in return argument:
	HwAPI does not implement LowLevelHardwareInterfaces (missing ReadPhys method)
/home/xaionaro/go-fbcode-3rdparty/pkg/mod/github.com/9elements/go-linux-lowlevel-hw@v0.0.0-20211215141225-8375dd201aae/pkg/hwapi/iommu.go:148:24: cannot use h (type HwAPI) as type LowLevelHardwareInterfaces in argument to lookupIOLegacy:
	HwAPI does not implement LowLevelHardwareInterfaces (missing ReadPhys method)
[xaionaro@void converged-security-suite]$
```

### after

```
[xaionaro@void converged-security-suite]$ GOARCH=386 go build ./cmd/pcr0tool
[xaionaro@void converged-security-suite]$ ./pcr0tool
error: no command specified

syntax: pcr0tool <command> [options] {arguments}

Possible commands:
    pcr0tool dump_registers                      dump status registers from /dev/mem and /dev/cpu/0/msr. Works only on Linux
    pcr0tool printnodes <firmware>               dump UEFI tree nodes
    pcr0tool sum <firmware>                      calculate the expected value of PCR0 for a specified firmware image
    pcr0tool diff <firmware_good> <firmware_bad> find the reason of different PCR0 values between two firmware images
    pcr0tool display_eventlog                    display TPM Event Log
    pcr0tool display_fwinfo <path to the image>  display information about firmware image
    pcr0tool dump_fit <firmware>                 dump FIT entries
```