### PR TITLE
An attempt to fix testdata/firmware/go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/9elements/converged-security-suite/v2
 go 1.13
 
 require (
-	github.com/9elements/converged-security-suite/v2/testdata/firmware v0.0.0-00010101000000-000000000000
+	github.com/9elements/converged-security-suite/testdata/firmware v0.0.0-20220517223030-8bb065875e61
 	github.com/9elements/go-linux-lowlevel-hw v0.0.0-20211215141225-8375dd201aae
 	github.com/alecthomas/kong v0.2.11
 	github.com/creasty/defaults v1.5.1
@@ -33,4 +33,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
 
-replace github.com/9elements/converged-security-suite/v2/testdata/firmware => ./testdata/firmware
+replace github.com/9elements/converged-security-suite/testdata/firmware => ./testdata/firmware

--- a/pkg/pcrbruteforcer/reproduce_event_log_test.go
+++ b/pkg/pcrbruteforcer/reproduce_event_log_test.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/9elements/converged-security-suite/testdata/firmware"
 	"github.com/9elements/converged-security-suite/v2/pkg/pcr"
 	"github.com/9elements/converged-security-suite/v2/pkg/registers"
 	"github.com/9elements/converged-security-suite/v2/pkg/tpmeventlog"
 	"github.com/9elements/converged-security-suite/v2/pkg/uefi"
-	"github.com/9elements/converged-security-suite/v2/testdata/firmware"
 	"github.com/google/go-tpm/tpm2"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/pcrbruteforcer/reproduce_expected_pcr0_test.go
+++ b/pkg/pcrbruteforcer/reproduce_expected_pcr0_test.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/9elements/converged-security-suite/testdata/firmware"
 	"github.com/9elements/converged-security-suite/v2/pkg/pcr"
 	"github.com/9elements/converged-security-suite/v2/pkg/registers"
 	"github.com/9elements/converged-security-suite/v2/pkg/uefi"
-	"github.com/9elements/converged-security-suite/v2/testdata/firmware"
 	"github.com/linuxboot/contest/pkg/xcontext/bundles/logrusctx"
 	"github.com/linuxboot/contest/pkg/xcontext/logger"
 

--- a/pkg/uefi/fiano_bench_test.go
+++ b/pkg/uefi/fiano_bench_test.go
@@ -3,7 +3,7 @@ package uefi
 import (
 	"testing"
 
-	"github.com/9elements/converged-security-suite/v2/testdata/firmware"
+	"github.com/9elements/converged-security-suite/testdata/firmware"
 	fianoUEFI "github.com/linuxboot/fiano/pkg/uefi"
 )
 

--- a/testdata/firmware/go.mod
+++ b/testdata/firmware/go.mod
@@ -1,4 +1,4 @@
-module github.com/9elements/converged-security-suite/v2/testdata/firmware
+module github.com/9elements/converged-security-suite/testdata/firmware
 
 go 1.17
 


### PR DESCRIPTION
The initial problem was introduced by me. I was trying to use `go:embed` in some tests without globally changing go version from 1.13 to 1.17. So I created a dedicated `go.mod` file for `testdata/firmware` (which uses `go:embed`). And to make things transparent, I did `replace`:
```
replace github.com/9elements/converged-security-suite/v2/testdata/firmware => ./testdata/firmware
```
and
```
replace github.com/9elements/converged-security-suite/v2/ => ../../
```

But it appears `testdata/firmware` currently works only inside the repository. While when I try to reach `github.com/9elements/converged-security-suite/v2/testdata/firmware` externally I get:

    $ go get github.com/9elements/converged-security-suite/v2/testdata/firmware@v0.0.0-00010101000000-000000000000
    go get: github.com/9elements/converged-security-suite/v2/testdata/firmware@v0.0.0-00010101000000-000000000000: invalid version: unknown revision 000000000000

And in attempts of tuning the revision and version which works both internally and externally, I came up with this solution.