### PR TITLE
Add a skeleton of redesigned "pcr" package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/google/go-attestation v0.4.0
 	github.com/google/go-tpm v0.3.3-0.20210120190357-1ff48daca32f
 	github.com/google/uuid v1.3.0
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/klauspost/cpuid/v2 v2.0.9
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/linuxboot/contest v0.0.0-20220404120719-d952dfa563c4

--- a/pkg/bootflow/actions/commonactions/set_flow.go
+++ b/pkg/bootflow/actions/commonactions/set_flow.go
@@ -1,0 +1,23 @@
+package commonactions
+
+import (
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/types"
+)
+
+type setFlow struct {
+	nextFlowFunc   func() types.Flow
+	startStepIndex uint
+}
+
+func SetFlow(flowFunc func() types.Flow, stepIndex uint) types.Action {
+	return &setFlow{
+		nextFlowFunc:   flowFunc,
+		startStepIndex: stepIndex,
+	}
+}
+
+func (step *setFlow) Apply(state *types.State) error {
+	state.CurrentFlow = step.nextFlowFunc()
+	state.CurrentStepIdx = step.startStepIndex
+	return nil
+}

--- a/pkg/bootflow/actions/tpmactions/tpm_event.go
+++ b/pkg/bootflow/actions/tpmactions/tpm_event.go
@@ -4,10 +4,9 @@ import (
 	"fmt"
 
 	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/datasources"
-	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/trustchains"
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/trustchains/tpm"
 	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/types"
 	pcrtypes "github.com/9elements/converged-security-suite/v2/pkg/pcr/types"
-	"github.com/google/go-tpm/tpm2"
 )
 
 type TPMEvent struct {
@@ -22,25 +21,22 @@ func NewTPMEvent(
 	pcrIndex pcrtypes.ID,
 	dataSource datasources.DataSource,
 	eventData []byte,
-) *TPMEvent {
-	return &TPMEvent{
+) TPMEvent {
+	return TPMEvent{
 		DataSource: dataSource,
 		PCRIndex:   pcrIndex,
 		EventData:  eventData,
 	}
 }
 
-func (ev *TPMEvent) Apply(state *types.State) error {
+func (ev TPMEvent) Apply(state *types.State) error {
 	data, err := ev.DataSource.Data(state)
 	if err != nil {
 		return fmt.Errorf("unable to extract the data: %w", err)
 	}
 
-	return trustchains.TPMFunc(state, func(tpm *trustchains.TPM) error {
-		for _, hashAlgo := range []tpm2.Algorithm{
-			tpm2.AlgSHA1,
-			tpm2.AlgSHA256,
-		} {
+	return tpm.StateExec(state, func(t *tpm.TPM) error {
+		for _, hashAlgo := range tpm.SupportedHashAlgos() {
 			h, err := hashAlgo.Hash()
 			if err != nil {
 				return fmt.Errorf("unable to get hasher factory for algo %#v: %w", hashAlgo, err)
@@ -51,16 +47,16 @@ func (ev *TPMEvent) Apply(state *types.State) error {
 			}
 			digest := hasher.Sum(nil)
 
-			if err := tpm.TPMExtend(ev.PCRIndex, hashAlgo, digest); err != nil {
+			if err := t.TPMExtend(ev.PCRIndex, hashAlgo, digest); err != nil {
 				return fmt.Errorf("unable to extend: %w", err)
 			}
 
-			if err := tpm.TPMEventLogAdd(ev.PCRIndex, hashAlgo, digest, ev.EventData); err != nil {
+			if err := t.TPMEventLogAdd(ev.PCRIndex, hashAlgo, digest, ev.EventData); err != nil {
 				return fmt.Errorf("unable to add an entry to TPM EventLog: %w", err)
 			}
 		}
 
-		state.AddVerifiedData(tpm, *data)
+		state.AddVerifiedData(t, *data)
 		return nil
 	})
 }

--- a/pkg/bootflow/actions/tpmactions/tpm_event.go
+++ b/pkg/bootflow/actions/tpmactions/tpm_event.go
@@ -1,0 +1,66 @@
+package tpmactions
+
+import (
+	"fmt"
+
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/datasources"
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/trustchains"
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/types"
+	pcrtypes "github.com/9elements/converged-security-suite/v2/pkg/pcr/types"
+	"github.com/google/go-tpm/tpm2"
+)
+
+type TPMEvent struct {
+	DataSource datasources.DataSource
+	PCRIndex   pcrtypes.ID
+	EventData  []byte
+}
+
+var _ types.Action = (*TPMEvent)(nil)
+
+func NewTPMEvent(
+	pcrIndex pcrtypes.ID,
+	dataSource datasources.DataSource,
+	eventData []byte,
+) *TPMEvent {
+	return &TPMEvent{
+		DataSource: dataSource,
+		PCRIndex:   pcrIndex,
+		EventData:  eventData,
+	}
+}
+
+func (ev *TPMEvent) Apply(state *types.State) error {
+	data, err := ev.DataSource.Data(state)
+	if err != nil {
+		return fmt.Errorf("unable to extract the data: %w", err)
+	}
+
+	return trustchains.TPMFunc(state, func(tpm *trustchains.TPM) error {
+		for _, hashAlgo := range []tpm2.Algorithm{
+			tpm2.AlgSHA1,
+			tpm2.AlgSHA256,
+		} {
+			h, err := hashAlgo.Hash()
+			if err != nil {
+				return fmt.Errorf("unable to get hasher factory for algo %#v: %w", hashAlgo, err)
+			}
+			hasher := h.New()
+			if _, err := hasher.Write(data.Bytes()); err != nil {
+				return fmt.Errorf("unable to hash data with %T: %w", hasher, err)
+			}
+			digest := hasher.Sum(nil)
+
+			if err := tpm.TPMExtend(ev.PCRIndex, hashAlgo, digest); err != nil {
+				return fmt.Errorf("unable to extend: %w", err)
+			}
+
+			if err := tpm.TPMEventLogAdd(ev.PCRIndex, hashAlgo, digest, ev.EventData); err != nil {
+				return fmt.Errorf("unable to add an entry to TPM EventLog: %w", err)
+			}
+		}
+
+		state.AddVerifiedData(tpm, *data)
+		return nil
+	})
+}

--- a/pkg/bootflow/actions/tpmactions/tpm_event.go
+++ b/pkg/bootflow/actions/tpmactions/tpm_event.go
@@ -60,3 +60,10 @@ func (ev TPMEvent) Apply(state *types.State) error {
 		return nil
 	})
 }
+
+func (ev TPMEvent) GoString() string {
+	if len(ev.EventData) == 0 {
+		return fmt.Sprintf("TPMEvent(PCR: %d, DataSource: %#v)", ev.PCRIndex, ev.DataSource)
+	}
+	return fmt.Sprintf("TPMEvent(PCR: %d, DataSource: %#v, EventData: %X)", ev.PCRIndex, ev.DataSource, ev.EventData)
+}

--- a/pkg/bootflow/actions/tpmactions/tpm_extend.go
+++ b/pkg/bootflow/actions/tpmactions/tpm_extend.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/datasources"
-	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/trustchains"
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/trustchains/tpm"
 	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/types"
 	pcrtypes "github.com/9elements/converged-security-suite/v2/pkg/pcr/types"
 	"github.com/google/go-tpm/tpm2"
@@ -22,27 +22,27 @@ func NewTPMExtend(
 	pcrIndex pcrtypes.ID,
 	dataSource datasources.DataSource,
 	hashAlgo tpm2.Algorithm,
-) *TPMExtend {
-	return &TPMExtend{
+) TPMExtend {
+	return TPMExtend{
 		DataSource: dataSource,
 		PCRIndex:   pcrIndex,
 		HashAlgo:   hashAlgo,
 	}
 }
 
-func (ext *TPMExtend) Apply(state *types.State) error {
+func (ext TPMExtend) Apply(state *types.State) error {
 	data, err := ext.DataSource.Data(state)
 	if err != nil {
 		return fmt.Errorf("unable to extract the data: %w", err)
 	}
 
-	return trustchains.TPMFunc(state, func(tpm *trustchains.TPM) error {
-		err := tpm.TPMExtend(ext.PCRIndex, ext.HashAlgo, data.Bytes())
+	return tpm.StateExec(state, func(t *tpm.TPM) error {
+		err := t.TPMExtend(ext.PCRIndex, ext.HashAlgo, data.Bytes())
 		if err != nil {
 			return fmt.Errorf("unable to extend: %w", err)
 		}
 
-		state.AddVerifiedData(tpm, *data)
+		state.AddVerifiedData(t, *data)
 		return nil
 	})
 }

--- a/pkg/bootflow/actions/tpmactions/tpm_extend.go
+++ b/pkg/bootflow/actions/tpmactions/tpm_extend.go
@@ -1,0 +1,48 @@
+package tpmactions
+
+import (
+	"fmt"
+
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/datasources"
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/trustchains"
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/types"
+	pcrtypes "github.com/9elements/converged-security-suite/v2/pkg/pcr/types"
+	"github.com/google/go-tpm/tpm2"
+)
+
+type TPMExtend struct {
+	DataSource datasources.DataSource
+	PCRIndex   pcrtypes.ID
+	HashAlgo   tpm2.Algorithm
+}
+
+var _ types.Action = (*TPMExtend)(nil)
+
+func NewTPMExtend(
+	pcrIndex pcrtypes.ID,
+	dataSource datasources.DataSource,
+	hashAlgo tpm2.Algorithm,
+) *TPMExtend {
+	return &TPMExtend{
+		DataSource: dataSource,
+		PCRIndex:   pcrIndex,
+		HashAlgo:   hashAlgo,
+	}
+}
+
+func (ext *TPMExtend) Apply(state *types.State) error {
+	data, err := ext.DataSource.Data(state)
+	if err != nil {
+		return fmt.Errorf("unable to extract the data: %w", err)
+	}
+
+	return trustchains.TPMFunc(state, func(tpm *trustchains.TPM) error {
+		err := tpm.TPMExtend(ext.PCRIndex, ext.HashAlgo, data.Bytes())
+		if err != nil {
+			return fmt.Errorf("unable to extend: %w", err)
+		}
+
+		state.AddVerifiedData(tpm, *data)
+		return nil
+	})
+}

--- a/pkg/bootflow/actions/tpmactions/tpm_init.go
+++ b/pkg/bootflow/actions/tpmactions/tpm_init.go
@@ -18,11 +18,11 @@ func NewTPMInit(locality uint8) TPMInit {
 }
 
 func (init TPMInit) Apply(state *types.State) error {
-	return tpm.StateExec(state, func(_tpm *tpm.TPM) error {
-		if _tpm.IsInitialized() {
+	return tpm.StateExec(state, func(t *tpm.TPM) error {
+		if t.IsInitialized() {
 			return nil
 		}
-		return _tpm.TPMInit(init.Locality)
+		return t.TPMInit(init.Locality)
 	})
 }
 

--- a/pkg/bootflow/actions/tpmactions/tpm_init.go
+++ b/pkg/bootflow/actions/tpmactions/tpm_init.go
@@ -1,0 +1,42 @@
+package tpmactions
+
+import (
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/trustchains/tpm"
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/types"
+)
+
+type TPMInit struct {
+	Locality uint8
+}
+
+func NewTPMInit(locality uint8) TPMInit {
+	return TPMInit{
+		Locality: locality,
+	}
+}
+
+func (init TPMInit) Apply(state *types.State) error {
+	return tpm.StateExec(state, func(_tpm *tpm.TPM) error {
+		if _tpm.IsInitialized() {
+			return nil
+		}
+		return _tpm.TPMInit(init.Locality)
+	})
+}
+
+type TPMInitLazy struct {
+	TPMInit
+}
+
+func NewTPMInitLazy(locality uint8) TPMInitLazy {
+	return TPMInitLazy{TPMInit: NewTPMInit(locality)}
+}
+
+func (init TPMInitLazy) Apply(state *types.State) error {
+	return tpm.StateExec(state, func(t *tpm.TPM) error {
+		if t.IsInitialized() {
+			return nil
+		}
+		return init.TPMInit.Apply(state)
+	})
+}

--- a/pkg/bootflow/actions/tpmactions/tpm_init.go
+++ b/pkg/bootflow/actions/tpmactions/tpm_init.go
@@ -1,6 +1,8 @@
 package tpmactions
 
 import (
+	"fmt"
+
 	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/trustchains/tpm"
 	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/types"
 )
@@ -39,4 +41,8 @@ func (init TPMInitLazy) Apply(state *types.State) error {
 		}
 		return init.TPMInit.Apply(state)
 	})
+}
+
+func (init TPMInitLazy) GoString() string {
+	return fmt.Sprintf("TPMInit(0)")
 }

--- a/pkg/bootflow/actions/tpmactions/tpm_init.go
+++ b/pkg/bootflow/actions/tpmactions/tpm_init.go
@@ -26,6 +26,10 @@ func (init TPMInit) Apply(state *types.State) error {
 	})
 }
 
+func (init TPMInit) GoString() string {
+	return fmt.Sprintf("TPMInit(%d)", init.Locality)
+}
+
 type TPMInitLazy struct {
 	TPMInit
 }
@@ -44,5 +48,5 @@ func (init TPMInitLazy) Apply(state *types.State) error {
 }
 
 func (init TPMInitLazy) GoString() string {
-	return fmt.Sprintf("TPMInit(0)")
+	return fmt.Sprintf("TPMInitLazy(%d)", init.Locality)
 }

--- a/pkg/bootflow/actions/tpmactions/tpm_init.go
+++ b/pkg/bootflow/actions/tpmactions/tpm_init.go
@@ -19,9 +19,6 @@ func NewTPMInit(locality uint8) TPMInit {
 
 func (init TPMInit) Apply(state *types.State) error {
 	return tpm.StateExec(state, func(t *tpm.TPM) error {
-		if t.IsInitialized() {
-			return nil
-		}
 		return t.TPMInit(init.Locality)
 	})
 }

--- a/pkg/bootflow/bootengine/boot_process.go
+++ b/pkg/bootflow/bootengine/boot_process.go
@@ -1,0 +1,78 @@
+package bootengine
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/types"
+)
+
+type BootProcess struct {
+	// Do not mutate these values from the outside, the mutability
+	// is owned by BootProcess itself.
+	CurrentState *types.State
+	Log          Log
+}
+
+func NewBootProcess(state *types.State) *BootProcess {
+	return &BootProcess{
+		CurrentState: state,
+	}
+}
+
+func stateNextStep(state *types.State) (types.Step, StepIssues, bool) {
+	if state.CurrentFlow == nil {
+		return nil, nil, false
+	}
+
+	if state.CurrentStepIdx >= uint(len(state.CurrentFlow)) {
+		return nil, nil, false
+	}
+
+	step := state.CurrentFlow[state.CurrentStepIdx]
+	actions := step.Actions(state)
+	var stepIssues StepIssues
+	for idx, action := range actions {
+		issue := action.Apply(state)
+		if issue != nil {
+			stepIssues = append(stepIssues, StepIssue{ActionIndex: uint(idx), Issue: issue})
+		}
+	}
+
+	state.CurrentStepIdx++
+	return step, stepIssues, true
+}
+
+func (process *BootProcess) NextStep() bool {
+	oldVerifiedData := process.CurrentState.VerifiedData
+	stepBackend, stepIssues, ok := stateNextStep(process.CurrentState)
+	if !ok {
+		return false
+	}
+	step := Step{Step: stepBackend}
+	step.Issues = stepIssues
+
+	if len(process.CurrentState.VerifiedData) > len(oldVerifiedData) {
+		step.VerifiedData = process.CurrentState.VerifiedData[len(oldVerifiedData):]
+	}
+
+	process.Log = append(process.Log, step)
+	return true
+}
+
+func (process *BootProcess) Finish() {
+	for process.NextStep() {
+	}
+}
+
+func (process *BootProcess) GoString() string {
+	var result strings.Builder
+	fmt.Fprintf(&result, "Current state:\n\t%s\n", nestedGoStringOf(process.CurrentState))
+	fmt.Fprintf(&result, "Resulting steps:\n\t%s\n", nestedGoStringOf(process.Log))
+	return result.String()
+}
+
+func nestedGoStringOf(i interface{}) string {
+	v := fmt.Sprintf("%#v", i)
+	return strings.ReplaceAll(strings.Trim(v, "\n"), "\n", "\n\t")
+}

--- a/pkg/bootflow/bootengine/boot_process.go
+++ b/pkg/bootflow/bootengine/boot_process.go
@@ -20,13 +20,13 @@ func NewBootProcess(state *types.State) *BootProcess {
 	}
 }
 
-func stateNextStep(state *types.State) (types.Step, StepIssues, bool) {
+func stateNextStep(state *types.State) (types.Step, types.Actions, StepIssues, bool) {
 	if state.CurrentFlow == nil {
-		return nil, nil, false
+		return nil, nil, nil, false
 	}
 
 	if state.CurrentStepIdx >= uint(len(state.CurrentFlow)) {
-		return nil, nil, false
+		return nil, nil, nil, false
 	}
 
 	step := state.CurrentFlow[state.CurrentStepIdx]
@@ -40,16 +40,16 @@ func stateNextStep(state *types.State) (types.Step, StepIssues, bool) {
 	}
 
 	state.CurrentStepIdx++
-	return step, stepIssues, true
+	return step, actions, stepIssues, true
 }
 
 func (process *BootProcess) NextStep() bool {
 	oldVerifiedData := process.CurrentState.VerifiedData
-	stepBackend, stepIssues, ok := stateNextStep(process.CurrentState)
+	stepBackend, actions, stepIssues, ok := stateNextStep(process.CurrentState)
 	if !ok {
 		return false
 	}
-	step := Step{Step: stepBackend}
+	step := Step{Step: stepBackend, Actions: actions}
 	step.Issues = stepIssues
 
 	if len(process.CurrentState.VerifiedData) > len(oldVerifiedData) {

--- a/pkg/bootflow/bootengine/issue.go
+++ b/pkg/bootflow/bootengine/issue.go
@@ -1,0 +1,16 @@
+package bootengine
+
+type StepIssue struct {
+	ActionIndex uint
+	Issue       error
+}
+
+func (err StepIssue) Error() string {
+	return err.Unwrap().Error()
+}
+
+func (err StepIssue) Unwrap() error {
+	return err.Issue
+}
+
+type StepIssues []StepIssue

--- a/pkg/bootflow/bootengine/log.go
+++ b/pkg/bootflow/bootengine/log.go
@@ -1,0 +1,62 @@
+package bootengine
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/types"
+)
+
+type Step struct {
+	Step         types.Step
+	VerifiedData []types.VerifiedData
+	Issues       StepIssues
+}
+
+type Log []Step
+
+func (log Log) GoString() string {
+	var result strings.Builder
+	for idx, step := range log {
+		fmt.Fprintf(&result, "%d. %#v:\n", idx, step.Step)
+		if len(step.VerifiedData) > 0 {
+			fmt.Fprintf(&result, "\tVerifiedData:\n")
+			for idx, verifiedData := range step.VerifiedData {
+				fmt.Fprintf(&result, "\t\t%d. %#v\n", idx, nestedGoStringOf(verifiedData))
+			}
+		}
+		if len(step.Issues) > 0 {
+			fmt.Fprintf(&result, "\tIssues:\n")
+			for idx, issue := range step.Issues {
+				fmt.Fprintf(&result, "\t\t%d. %#v\n", idx, nestedGoStringOf(issue))
+			}
+		}
+	}
+	return result.String()
+}
+
+func (log Log) GetVerifiedDataByTrustChainType(trustChainSample types.TrustChain) []types.VerifiedData {
+	var result []types.VerifiedData
+	cmpType := reducedType(trustChainSample)
+	for _, step := range log {
+		if len(step.VerifiedData) == 0 {
+			continue
+		}
+		for _, verifiedData := range step.VerifiedData {
+			if reducedType(verifiedData.TrustChain) == cmpType {
+				result = append(result, verifiedData)
+			}
+		}
+	}
+
+	return result
+}
+
+func reducedType(i interface{}) reflect.Type {
+	k := reflect.TypeOf(i)
+	for k.Kind() == reflect.Ptr {
+		k = k.Elem()
+	}
+	return k
+}

--- a/pkg/bootflow/bootengine/log.go
+++ b/pkg/bootflow/bootengine/log.go
@@ -10,6 +10,7 @@ import (
 
 type Step struct {
 	Step         types.Step
+	Actions      types.Actions
 	VerifiedData []types.VerifiedData
 	Issues       StepIssues
 }
@@ -24,6 +25,12 @@ func (log Log) GoString() string {
 			fmt.Fprintf(&result, "\tVerifiedData:\n")
 			for idx, verifiedData := range step.VerifiedData {
 				fmt.Fprintf(&result, "\t\t%d. %#v\n", idx, nestedGoStringOf(verifiedData))
+			}
+		}
+		if _, ok := step.Step.(types.StaticStep); !ok && len(step.Actions) > 0 {
+			fmt.Fprintf(&result, "\tActions:\n")
+			for idx, action := range step.Actions {
+				fmt.Fprintf(&result, "\t\t%d. %#v\n", idx, nestedGoStringOf(action))
 			}
 		}
 		if len(step.Issues) > 0 {

--- a/pkg/bootflow/bootengine/log.go
+++ b/pkg/bootflow/bootengine/log.go
@@ -24,19 +24,19 @@ func (log Log) GoString() string {
 		if len(step.VerifiedData) > 0 {
 			fmt.Fprintf(&result, "\tVerifiedData:\n")
 			for idx, verifiedData := range step.VerifiedData {
-				fmt.Fprintf(&result, "\t\t%d. %#v\n", idx, nestedGoStringOf(verifiedData))
+				fmt.Fprintf(&result, "\t\t%d. %s\n", idx, nestedGoStringOf(verifiedData))
 			}
 		}
 		if _, ok := step.Step.(types.StaticStep); !ok && len(step.Actions) > 0 {
 			fmt.Fprintf(&result, "\tActions:\n")
 			for idx, action := range step.Actions {
-				fmt.Fprintf(&result, "\t\t%d. %#v\n", idx, nestedGoStringOf(action))
+				fmt.Fprintf(&result, "\t\t%d. %s\n", idx, nestedGoStringOf(action))
 			}
 		}
 		if len(step.Issues) > 0 {
 			fmt.Fprintf(&result, "\tIssues:\n")
 			for idx, issue := range step.Issues {
-				fmt.Fprintf(&result, "\t\t%d. %#v\n", idx, nestedGoStringOf(issue))
+				fmt.Fprintf(&result, "\t\t%d. %s\n", idx, nestedGoStringOf(issue))
 			}
 		}
 	}

--- a/pkg/bootflow/datasources/_autodocs.go
+++ b/pkg/bootflow/datasources/_autodocs.go
@@ -1,0 +1,8 @@
+//go:build none
+// +build none
+
+package datasources
+
+// This files is used only to provide hints to the "goplantuml" tool
+
+type UEFIGUIDFirst struct{}

--- a/pkg/bootflow/datasources/data_source.go
+++ b/pkg/bootflow/datasources/data_source.go
@@ -1,0 +1,7 @@
+package datasources
+
+import "github.com/9elements/converged-security-suite/v2/pkg/bootflow/types"
+
+type DataSource interface {
+	Data(*types.State) (*types.Data, error)
+}

--- a/pkg/bootflow/datasources/static_data.go
+++ b/pkg/bootflow/datasources/static_data.go
@@ -1,0 +1,11 @@
+package datasources
+
+import (
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/types"
+)
+
+type StaticData []byte
+
+func (d StaticData) Data(*types.State) (*types.Data, error) {
+	return &types.Data{ForceBytes: d}, nil
+}

--- a/pkg/bootflow/datasources/static_data.go
+++ b/pkg/bootflow/datasources/static_data.go
@@ -1,6 +1,8 @@
 package datasources
 
 import (
+	"fmt"
+
 	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/types"
 )
 
@@ -8,4 +10,8 @@ type StaticData []byte
 
 func (d StaticData) Data(*types.State) (*types.Data, error) {
 	return &types.Data{ForceBytes: d}, nil
+}
+
+func (d StaticData) GoString() string {
+	return fmt.Sprintf("StaticData{%X}", []byte(d))
 }

--- a/pkg/bootflow/datasources/uefi_guid.go
+++ b/pkg/bootflow/datasources/uefi_guid.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/systemartifacts"
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/systemartifacts/biosfirmware"
 	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/types"
 	"github.com/9elements/converged-security-suite/v2/pkg/uefi/ffs"
 	"github.com/hashicorp/go-multierror"
@@ -16,7 +16,7 @@ type UEFIGUIDFirst []guid.GUID
 
 func (ds UEFIGUIDFirst) Data(state *types.State) (*types.Data, error) {
 	var data *types.Data
-	err := systemartifacts.BIOSFirmwareFunc(state, func(fwRaw *systemartifacts.BIOSFirmware) error {
+	err := biosfirmware.FromState(state, func(fwRaw *biosfirmware.BIOSFirmware) error {
 		firmware, err := fwRaw.Parse()
 		if err != nil {
 			return fmt.Errorf("unable to parse the firmware image: %w", err)

--- a/pkg/bootflow/datasources/uefi_guid.go
+++ b/pkg/bootflow/datasources/uefi_guid.go
@@ -1,0 +1,68 @@
+package datasources
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/systemartifacts"
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/types"
+	"github.com/9elements/converged-security-suite/v2/pkg/uefi/ffs"
+	"github.com/hashicorp/go-multierror"
+	pkgbytes "github.com/linuxboot/fiano/pkg/bytes"
+	"github.com/linuxboot/fiano/pkg/guid"
+)
+
+type UEFIGUIDFirst []guid.GUID
+
+func (ds UEFIGUIDFirst) Data(state *types.State) (*types.Data, error) {
+	var data *types.Data
+	err := systemartifacts.BIOSFirmwareFunc(state, func(fwRaw *systemartifacts.BIOSFirmware) error {
+		firmware, err := fwRaw.Parse()
+		if err != nil {
+			return fmt.Errorf("unable to parse the firmware image: %w", err)
+		}
+
+		var volumes []*ffs.Node
+		for _, guid := range ds {
+			volumes, err = firmware.GetByGUID(guid)
+			if err != nil {
+				return fmt.Errorf("unable to get volumes with GUID '%s': %w", guid, err)
+			}
+			if len(volumes) > 0 {
+				break
+			}
+		}
+		if len(volumes) == 0 {
+			return fmt.Errorf("no volumes with GUIDs %#+v found", ds)
+		}
+
+		var (
+			ranges pkgbytes.Ranges
+			mErr   multierror.Error
+		)
+		for _, volume := range volumes {
+			if volume.Offset == math.MaxUint64 {
+				// Was unable to detect the offset; it is expected
+				// if the volume is in a compressed area.
+				mErr.Errors = append(mErr.Errors, fmt.Errorf("unable to detect the offset of a DXE volume"))
+				continue
+			}
+			ranges = append(ranges, volume.Range)
+		}
+		if len(ranges) == 0 {
+			return mErr.ErrorOrNil()
+		}
+
+		data = &types.Data{
+			References: []types.Reference{{
+				Artifact: fwRaw,
+				Ranges:   ranges,
+			}},
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unable to extract an UEFI volume with GUIDs %+v: %w", ds, err)
+	}
+	return data, nil
+}

--- a/pkg/bootflow/examples/bruteforce/main.go
+++ b/pkg/bootflow/examples/bruteforce/main.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha1"
+	"fmt"
+	"hash"
+
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/bootengine"
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/steps/tpmsteps"
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/trustchains/tpm"
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/types"
+	"github.com/9elements/converged-security-suite/v2/pkg/bruteforcer"
+	"github.com/google/go-tpm/tpm2"
+)
+
+func main() {
+	// Here we brute-force a TPM measurement against a final PCR0 value.
+	//
+	// We initially have measurements of two separators, but we need to
+	// bruteforce the first measurement to 0x01000001
+
+	// an artificial flow for two separators
+	myFlow := types.Flow{
+		tpmsteps.InitTPMLazy(0),
+		tpmsteps.MeasureSeparator(0),
+		tpmsteps.MeasureSeparator(0),
+	}
+
+	// the expected final hash (after bruteforcing)
+	expectedHash := make([]byte, sha1.Size)
+	extend := func(h hash.Hash, a, b []byte) []byte {
+		defer h.Reset()
+		h.Write(a)
+		h.Write(b)
+		return h.Sum(nil)
+	}
+	sep0, sep1 := sha1.Sum([]byte("\x01\x00\x00\x01")), sha1.Sum([]byte("\x00\x00\x00\x00"))
+	expectedHash = extend(sha1.New(), expectedHash, sep0[:])
+	expectedHash = extend(sha1.New(), expectedHash, sep1[:])
+
+	// executing the flow (with two simple "\x00\x00\x00\x00" measurements)
+	state := types.NewState()
+	state.SetFlow(myFlow, 0)
+	state.EnableTrustChain(tpm.NewTPM())
+	process := bootengine.NewBootProcess(state)
+	process.Finish()
+
+	// just some debugging
+	fmt.Printf("Log:\n%#v\n", process.Log)
+
+	// == now let's bruteforce the first measurement ==
+
+	// first find the original (UNHASHED) data of the first measurement
+	tpmMeasurements := process.Log.GetVerifiedDataByTrustChainType((*tpm.TPM)(nil))
+
+	// now let's gather the rest chain (TPM init and the rest TPM Extend-s)
+	var (
+		tpmLocality *uint8
+		tpmExtends  []tpm.CommandLogEntryExtend
+	)
+	tpm.StateExec(state, func(t *tpm.TPM) error {
+		for _, entry := range t.CommandLog {
+			switch entry := entry.(type) {
+			case tpm.CommandLogEntryInit:
+				tpmLocality = &[]uint8{entry.Locality}[0]
+			case tpm.CommandLogEntryExtend:
+				if entry.HashAlgo != tpm2.AlgSHA1 {
+					continue
+				}
+				tpmExtends = append(tpmExtends, entry)
+			}
+		}
+		return nil
+	})
+	if tpmLocality == nil {
+		panic("the TPMInit command wasn't found")
+	}
+
+	// let's construct the final flow:
+
+	type context struct {
+		sha1Hasher hash.Hash
+	}
+	combination, err := bruteforcer.BruteForceBytes(
+		tpmMeasurements[0].Data.ForceBytes,
+		2,
+		func() (interface{}, error) {
+			return &context{
+				sha1Hasher: sha1.New(),
+			}, nil
+		},
+		func(_ctx interface{}, data []byte) bool {
+			ctx := _ctx.(*context)
+			h := ctx.sha1Hasher
+
+			// starting a PCR value from scratch:
+			pcrValue := make([]byte, sha1.Size)
+			pcrValue[len(pcrValue)-1] = *tpmLocality
+
+			// hashing the bruteforced value before extending
+			h.Write(data)
+			dataHashed := h.Sum(nil)
+			h.Reset()
+
+			// extending it
+			pcrValue = extend(h, pcrValue, dataHashed)
+
+			// extending the rest of the measurements (they are already pre-hashed)
+			for _, tpmExtend := range tpmExtends[1:] {
+				pcrValue = extend(h, pcrValue, tpmExtend.Digest)
+			}
+
+			// is it OK?
+			return bytes.Equal(pcrValue, expectedHash)
+		},
+		0,
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	// printing the result
+	result := []byte("\x00\x00\x00\x00")
+	combination.ApplyBitFlips(result)
+	fmt.Printf("COMBINATION: %#v\n", combination)
+	fmt.Printf("RESULT: 0x%X\n", result)
+
+	tpmMeasurements[0].Data.ForceBytes = result
+	fmt.Printf("resulting measurements: %#v\n", tpmMeasurements)
+}

--- a/pkg/bootflow/examples/bruteforce/main.go
+++ b/pkg/bootflow/examples/bruteforce/main.go
@@ -77,7 +77,7 @@ func main() {
 		panic("the TPMInit command wasn't found")
 	}
 
-	// let's construct the final flow:
+	// brute force:
 
 	type context struct {
 		sha1Hasher hash.Hash

--- a/pkg/bootflow/examples/ocpdxepcr0/main.go
+++ b/pkg/bootflow/examples/ocpdxepcr0/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/bootengine"
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/flows"
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/systemartifacts/biosfirmware"
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/trustchains/tpm"
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/types"
+	"github.com/google/go-tpm/tpm2"
+)
+
+func main() {
+	// parsing arguments
+	flag.Parse()
+	biosFirmwarePath := flag.Arg(0)
+	biosFirmware, err := os.ReadFile(biosFirmwarePath)
+	if err != nil {
+		panic(fmt.Errorf("unable to read BIOS firmware image '%s': %w", biosFirmwarePath, err))
+	}
+
+	// the main part
+	state := types.NewState()
+	state.SetFlow(flows.OCPDXE(), 0)
+	state.EnableTrustChain(tpm.NewTPM())
+	state.EnableSystemArtifact(biosfirmware.NewBIOSFirmware(biosFirmware))
+	process := bootengine.NewBootProcess(state)
+	process.Finish()
+
+	// printing results
+	tpm.StateExec(state, func(t *tpm.TPM) error {
+		fmt.Printf("PCR values:\n")
+		for pcrID, values := range t.PCRValues {
+			fmt.Printf("\tPCR[%d]: SHA1:%X\n", pcrID, values[tpm2.AlgSHA1])
+		}
+		fmt.Printf("TPM EventLog:\n")
+		for idx, entry := range t.EventLog {
+			if entry.HashAlgo != tpm2.AlgSHA1 {
+				continue
+			}
+			fmt.Printf("\t%d: %#v\n", idx, entry)
+		}
+		fmt.Printf("TPM commands log:\n")
+		for idx, entry := range t.CommandLog {
+			if entry, ok := entry.(tpm.CommandLogEntryExtend); ok {
+				if entry.HashAlgo != tpm2.AlgSHA1 {
+					continue
+				}
+			}
+			fmt.Printf("\t%d: %#v\n", idx, entry)
+		}
+		return nil
+	})
+}

--- a/pkg/bootflow/flows/_autodocs.go
+++ b/pkg/bootflow/flows/_autodocs.go
@@ -1,0 +1,16 @@
+//go:build none
+// +build none
+
+package flows
+
+import (
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/steps/tpmsteps"
+)
+
+// This files is used only to provide hints to the "goplantuml" tool
+
+type OCPDXE struct {
+	tpmsteps.MeasurePCD
+	tpmsteps.MeasureUEFIGUIDFirst
+	tpmsteps.MeasureSeparator
+}

--- a/pkg/bootflow/flows/ocp_dxe.go
+++ b/pkg/bootflow/flows/ocp_dxe.go
@@ -1,0 +1,15 @@
+package flows
+
+import (
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/steps/tpmsteps"
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/types"
+	ffsConsts "github.com/9elements/converged-security-suite/v2/pkg/uefi/ffs/consts"
+)
+
+func OCPDXE() types.Flow {
+	return types.Flow{
+		tpmsteps.MeasurePCD("FirmwareVendorVersion"),
+		tpmsteps.MeasureUEFIGUIDFirst(ffsConsts.GUIDDXE, ffsConsts.GUIDDXEContainer),
+		tpmsteps.MeasureSeparator(0),
+	}
+}

--- a/pkg/bootflow/flows/ocp_dxe.go
+++ b/pkg/bootflow/flows/ocp_dxe.go
@@ -8,8 +8,8 @@ import (
 
 func OCPDXE() types.Flow {
 	return types.Flow{
-		tpmsteps.MeasurePCD("FirmwareVendorVersion"),
-		tpmsteps.MeasureUEFIGUIDFirst(ffsConsts.GUIDDXE, ffsConsts.GUIDDXEContainer),
+		tpmsteps.MeasurePCDVariable(0, "FirmwareVendorVersion"),
+		tpmsteps.MeasureUEFIGUIDFirst(0, ffsConsts.GUIDDXE, ffsConsts.GUIDDXEContainer),
 		tpmsteps.MeasureSeparator(0),
 	}
 }

--- a/pkg/bootflow/flows/ocp_dxe.go
+++ b/pkg/bootflow/flows/ocp_dxe.go
@@ -8,6 +8,7 @@ import (
 
 func OCPDXE() types.Flow {
 	return types.Flow{
+		tpmsteps.InitTPMLazy(0),
 		tpmsteps.MeasurePCDVariable(0, "FirmwareVendorVersion"),
 		tpmsteps.MeasureUEFIGUIDFirst(0, ffsConsts.GUIDDXE, ffsConsts.GUIDDXEContainer),
 		tpmsteps.MeasureSeparator(0),

--- a/pkg/bootflow/steps/commonsteps/_autodocs.go
+++ b/pkg/bootflow/steps/commonsteps/_autodocs.go
@@ -1,0 +1,10 @@
+//go:build none
+// +build none
+
+package commonsteps
+
+// This files is used only to provide hints to the "goplantuml" tool
+
+type setFlow struct {
+	commonactions.setFlow
+}

--- a/pkg/bootflow/steps/commonsteps/set_flow.go
+++ b/pkg/bootflow/steps/commonsteps/set_flow.go
@@ -1,0 +1,24 @@
+package commonsteps
+
+import (
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/actions/commonactions"
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/types"
+)
+
+type setFlow struct {
+	nextFlowFunc   func() types.Flow
+	startStepIndex uint
+}
+
+func SetFlow(flowFunc func() types.Flow, stepIndex uint) types.Step {
+	return &setFlow{
+		nextFlowFunc:   flowFunc,
+		startStepIndex: stepIndex,
+	}
+}
+
+func (step *setFlow) Actions(state *types.State) types.Actions {
+	return types.Actions{
+		commonactions.SetFlow(step.nextFlowFunc, step.startStepIndex),
+	}
+}

--- a/pkg/bootflow/steps/tpmsteps/_autodocs.go
+++ b/pkg/bootflow/steps/tpmsteps/_autodocs.go
@@ -1,0 +1,18 @@
+//go:build none
+// +build none
+
+package tpmsteps
+
+// This files is used only to provide hints to the "goplantuml" tool
+
+type MeasureSeparator struct {
+	types.StaticStep
+	tpmactions.TPMEvent
+	datasources.StaticData
+}
+
+type MeasureUEFIGUIDFirst struct {
+	types.StaticStep
+	tpmactions.TPMEvent
+	datasources.UEFIGUIDFirst
+}

--- a/pkg/bootflow/steps/tpmsteps/init_tpm.go
+++ b/pkg/bootflow/steps/tpmsteps/init_tpm.go
@@ -1,0 +1,12 @@
+package tpmsteps
+
+import (
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/actions/tpmactions"
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/types"
+)
+
+func InitTPMLazy(locality uint8) types.Step {
+	return types.StaticStep{
+		tpmactions.NewTPMInitLazy(locality),
+	}
+}

--- a/pkg/bootflow/steps/tpmsteps/measure_pcd.go
+++ b/pkg/bootflow/steps/tpmsteps/measure_pcd.go
@@ -1,0 +1,11 @@
+package tpmsteps
+
+import (
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/types"
+)
+
+func MeasurePCD(variableName string) types.Step {
+	return types.StaticStep{
+		// not implemented, yet
+	}
+}

--- a/pkg/bootflow/steps/tpmsteps/measure_pcd.go
+++ b/pkg/bootflow/steps/tpmsteps/measure_pcd.go
@@ -2,9 +2,10 @@ package tpmsteps
 
 import (
 	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/types"
+	pcrtypes "github.com/9elements/converged-security-suite/v2/pkg/pcr/types"
 )
 
-func MeasurePCD(variableName string) types.Step {
+func MeasurePCDVariable(pcrID pcrtypes.ID, name string) types.Step {
 	return types.StaticStep{
 		// not implemented, yet
 	}

--- a/pkg/bootflow/steps/tpmsteps/measure_separator.go
+++ b/pkg/bootflow/steps/tpmsteps/measure_separator.go
@@ -1,0 +1,14 @@
+package tpmsteps
+
+import (
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/actions/tpmactions"
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/datasources"
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/types"
+	pcrtypes "github.com/9elements/converged-security-suite/v2/pkg/pcr/types"
+)
+
+func MeasureSeparator(pcrID pcrtypes.ID) types.Step {
+	return types.StaticStep{
+		tpmactions.NewTPMEvent(0, datasources.StaticData{0, 0, 0, 0}, nil),
+	}
+}

--- a/pkg/bootflow/steps/tpmsteps/measure_uefi_guid.go
+++ b/pkg/bootflow/steps/tpmsteps/measure_uefi_guid.go
@@ -1,0 +1,14 @@
+package tpmsteps
+
+import (
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/actions/tpmactions"
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/datasources"
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/types"
+	"github.com/linuxboot/fiano/pkg/guid"
+)
+
+func MeasureUEFIGUIDFirst(orList ...guid.GUID) types.Step {
+	return types.StaticStep{
+		tpmactions.NewTPMEvent(0, datasources.UEFIGUIDFirst(orList), nil),
+	}
+}

--- a/pkg/bootflow/steps/tpmsteps/measure_uefi_guid.go
+++ b/pkg/bootflow/steps/tpmsteps/measure_uefi_guid.go
@@ -4,11 +4,12 @@ import (
 	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/actions/tpmactions"
 	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/datasources"
 	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/types"
+	pcrtypes "github.com/9elements/converged-security-suite/v2/pkg/pcr/types"
 	"github.com/linuxboot/fiano/pkg/guid"
 )
 
-func MeasureUEFIGUIDFirst(orList ...guid.GUID) types.Step {
+func MeasureUEFIGUIDFirst(pcrID pcrtypes.ID, orList ...guid.GUID) types.Step {
 	return types.StaticStep{
-		tpmactions.NewTPMEvent(0, datasources.UEFIGUIDFirst(orList), nil),
+		tpmactions.NewTPMEvent(pcrID, datasources.UEFIGUIDFirst(orList), nil),
 	}
 }

--- a/pkg/bootflow/systemartifacts/biosfirmware/bios_firmware.go
+++ b/pkg/bootflow/systemartifacts/biosfirmware/bios_firmware.go
@@ -1,4 +1,4 @@
-package systemartifacts
+package biosfirmware
 
 import (
 	"bytes"
@@ -16,14 +16,14 @@ type BIOSFirmware struct {
 	CacheParseError error
 }
 
-func BIOSFirmwareFunc(state *types.State, fn func(fw *BIOSFirmware) error) error {
-	for _, artifact := range state.SystemArtifacts {
-		if artifact, ok := artifact.(*BIOSFirmware); ok {
-			return fn(artifact)
-		}
-	}
+func NewBIOSFirmware(content []byte) *BIOSFirmware {
+	return &BIOSFirmware{Content: content}
+}
 
-	return fmt.Errorf("unable to find a BIOS firmware in the list of artifacts")
+func FromState(state *types.State, fn func(fw *BIOSFirmware) error) error {
+	return state.SystemArtifactExec((*BIOSFirmware)(nil), func(artifact types.SystemArtifact) error {
+		return fn(artifact.(*BIOSFirmware))
+	})
 }
 
 func (fw *BIOSFirmware) Size() uint {
@@ -40,4 +40,8 @@ func (fw *BIOSFirmware) Parse() (*uefi.UEFI, error) {
 	}
 
 	return fw.CacheParsed, fw.CacheParseError
+}
+
+func (fw *BIOSFirmware) GoString() string {
+	return fmt.Sprintf("[%d]byte{}", len(fw.Content))
 }

--- a/pkg/bootflow/systemartifacts/system_artifact_bios_firmware.go
+++ b/pkg/bootflow/systemartifacts/system_artifact_bios_firmware.go
@@ -1,0 +1,43 @@
+package systemartifacts
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/types"
+	"github.com/9elements/converged-security-suite/v2/pkg/uefi"
+)
+
+var _ types.SystemArtifact = (*BIOSFirmware)(nil)
+
+type BIOSFirmware struct {
+	Content         []byte
+	CacheParsed     *uefi.UEFI
+	CacheParseError error
+}
+
+func BIOSFirmwareFunc(state *types.State, fn func(fw *BIOSFirmware) error) error {
+	for _, artifact := range state.SystemArtifacts {
+		if artifact, ok := artifact.(*BIOSFirmware); ok {
+			return fn(artifact)
+		}
+	}
+
+	return fmt.Errorf("unable to find a BIOS firmware in the list of artifacts")
+}
+
+func (fw *BIOSFirmware) Size() uint {
+	return uint(len(fw.Content))
+}
+
+func (fw *BIOSFirmware) ReadAt(b []byte, offset int64) (n int, err error) {
+	return bytes.NewReader(fw.Content).ReadAt(b, offset)
+}
+
+func (fw *BIOSFirmware) Parse() (*uefi.UEFI, error) {
+	if fw.CacheParsed == nil && fw.CacheParseError == nil {
+		fw.CacheParsed, fw.CacheParseError = uefi.ParseUEFIFirmwareBytes(fw.Content)
+	}
+
+	return fw.CacheParsed, fw.CacheParseError
+}

--- a/pkg/bootflow/trustchains/_autodocs.go
+++ b/pkg/bootflow/trustchains/_autodocs.go
@@ -1,0 +1,19 @@
+//go:build none
+// +build none
+
+package trustchains
+
+import (
+	pcrtypes "github.com/9elements/converged-security-suite/v2/pkg/pcr/types"
+)
+
+// This files is used only to provide hints to the "goplantuml" tool
+
+type TPM struct {
+	TPMEventLog
+	PCRValues
+}
+
+type TPMEventLogEntry struct {
+	PCRID
+}

--- a/pkg/bootflow/trustchains/tpm/_autodocs.go
+++ b/pkg/bootflow/trustchains/tpm/_autodocs.go
@@ -1,7 +1,7 @@
 //go:build none
 // +build none
 
-package trustchains
+package tpm
 
 import (
 	pcrtypes "github.com/9elements/converged-security-suite/v2/pkg/pcr/types"
@@ -10,10 +10,10 @@ import (
 // This files is used only to provide hints to the "goplantuml" tool
 
 type TPM struct {
-	TPMEventLog
+	EventLog
 	PCRValues
 }
 
-type TPMEventLogEntry struct {
+type EventLogEntry struct {
 	PCRID
 }

--- a/pkg/bootflow/trustchains/tpm/command_log.go
+++ b/pkg/bootflow/trustchains/tpm/command_log.go
@@ -1,0 +1,39 @@
+package tpm
+
+import (
+	"fmt"
+
+	"github.com/google/go-tpm/tpm2"
+)
+
+type CommandLog []CommandLogEntry
+
+type CommandLogEntry interface {
+	LogString() string
+}
+
+type CommandLogEntryInit struct {
+	Locality uint8
+}
+
+func (entry CommandLogEntryInit) LogString() string {
+	return fmt.Sprintf("TPMInit(%d)", entry.Locality)
+}
+
+func (entry CommandLogEntryInit) GoString() string {
+	return entry.LogString()
+}
+
+type CommandLogEntryExtend struct {
+	PCRIndex PCRID
+	HashAlgo tpm2.Algorithm
+	Digest   Digest
+}
+
+func (entry CommandLogEntryExtend) LogString() string {
+	return fmt.Sprintf("TPMExtend(%d, %s, %X)", entry.PCRIndex, entry.HashAlgo, entry.Digest)
+}
+
+func (entry CommandLogEntryExtend) GoString() string {
+	return entry.LogString()
+}

--- a/pkg/bootflow/trustchains/tpm/digest.go
+++ b/pkg/bootflow/trustchains/tpm/digest.go
@@ -1,0 +1,9 @@
+package tpm
+
+import "fmt"
+
+type Digest []byte
+
+func (d Digest) GoString() string {
+	return fmt.Sprintf("0x%X", []byte(d))
+}

--- a/pkg/bootflow/trustchains/tpm/event_log.go
+++ b/pkg/bootflow/trustchains/tpm/event_log.go
@@ -1,0 +1,38 @@
+package tpm
+
+import (
+	"fmt"
+
+	"github.com/google/go-tpm/tpm2"
+)
+
+type EventLog []EventLogEntry
+
+type EventLogEntry struct {
+	PCRIndex PCRID
+	HashAlgo tpm2.Algorithm
+	Digest   Digest
+	Data     []byte
+}
+
+func (entry EventLogEntry) GoString() string {
+	if len(entry.Data) == 0 {
+		return fmt.Sprintf(
+			"{PCR: %d, Alg: %s, Digest: %#v}",
+			entry.PCRIndex, entry.HashAlgo, entry.Digest,
+		)
+	}
+	return fmt.Sprintf(
+		"{PCR: %d, Alg: %s, Digest: %#v, Data: 0x%X}",
+		entry.PCRIndex, entry.HashAlgo, entry.Digest, entry.Data,
+	)
+}
+
+func (log *EventLog) Add(pcrIndex PCRID, hashAlgo tpm2.Algorithm, digest, data []byte) {
+	*log = append(*log, EventLogEntry{
+		PCRIndex: pcrIndex,
+		HashAlgo: hashAlgo,
+		Digest:   digest,
+		Data:     data,
+	})
+}

--- a/pkg/bootflow/trustchains/trust_chain_tpm.go
+++ b/pkg/bootflow/trustchains/trust_chain_tpm.go
@@ -1,0 +1,108 @@
+package trustchains
+
+import (
+	"fmt"
+
+	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/types"
+	pcrtypes "github.com/9elements/converged-security-suite/v2/pkg/pcr/types"
+	"github.com/google/go-tpm/tpm2"
+)
+
+var _ types.TrustChain = (*TPM)(nil)
+
+type TPM struct {
+	PCRValues PCRValues
+	EventLog  TPMEventLog
+}
+
+func TPMFunc(state *types.State, fn func(tpm *TPM) error) error {
+	for _, trustChain := range state.TrustChains {
+		if tpm, ok := trustChain.(*TPM); ok {
+			return fn(tpm)
+		}
+	}
+
+	return fmt.Errorf("unable to find a trust chain backed by TPM")
+}
+
+func (chain *TPM) IsInitialized() bool {
+	return len(chain.PCRValues) > 0
+}
+
+func (chain *TPM) TPMExtend(pcrIndex PCRID, hashAlgo tpm2.Algorithm, digest []byte) error {
+	h, err := hashAlgo.Hash()
+	if err != nil {
+		return fmt.Errorf("invalid hash algo: %w", err)
+	}
+	hasher := h.New()
+
+	oldValue, err := chain.PCRValues.Get(pcrIndex, hashAlgo)
+	if err != nil {
+		return fmt.Errorf("unable to get the PCR value: %w", err)
+	}
+	if _, err := hasher.Write(oldValue); err != nil {
+		return fmt.Errorf("unable to write into hasher %T the original value: %w", hasher, err)
+	}
+	if _, err := hasher.Write(digest); err != nil {
+		return fmt.Errorf("unable to write into hasher %T the given value: %w", hasher, err)
+	}
+	newValue := hasher.Sum(nil)
+	if err := chain.PCRValues.Set(pcrIndex, hashAlgo, newValue); err != nil {
+		return fmt.Errorf("unable to update the PCR value: %w", err)
+	}
+	return nil
+}
+
+func (chain *TPM) TPMEventLogAdd(pcrIndex PCRID, hashAlgo tpm2.Algorithm, digest, data []byte) error {
+	chain.EventLog.Add(pcrIndex, hashAlgo, digest, data)
+	return nil
+}
+
+type PCRValues [][][]byte
+
+type PCRID = pcrtypes.ID
+
+func (s PCRValues) Get(pcrID PCRID, hashAlg tpm2.Algorithm) ([]byte, error) {
+	if len(s) <= int(pcrID) {
+		return nil, fmt.Errorf("PCR %d is not initialized", pcrID)
+	}
+	if len(s[pcrID]) <= int(hashAlg) {
+		return nil, fmt.Errorf("PCR %d:%s is not initialized", pcrID, hashAlg)
+	}
+	return s[pcrID][hashAlg], nil
+}
+
+func (s PCRValues) Set(pcrID PCRID, hashAlg tpm2.Algorithm, value []byte) error {
+	if hashAlg > tpm2.AlgSHA3_512 {
+		panic(fmt.Errorf("too high value of hash algo: %d > %d", hashAlg, tpm2.AlgSHA3_512))
+	}
+
+	if len(s) <= int(pcrID) {
+		return fmt.Errorf("PCR %d is not initialized", pcrID)
+	}
+
+	if len(s[pcrID]) <= int(hashAlg) {
+		return fmt.Errorf("PCR %d:%s is not initialized", pcrID, hashAlg)
+	}
+
+	s[pcrID][hashAlg] = value
+	return nil
+}
+
+type TPMEventLog []TPMEventLogEntry
+
+type TPMEventLogEntry struct {
+	PCRIndex PCRID
+	HashAlgo tpm2.Algorithm
+	Digest   []byte
+	Data     []byte
+}
+
+func (log *TPMEventLog) Add(pcrIndex PCRID, hashAlgo tpm2.Algorithm, digest, data []byte) {
+	*log = append(*log, TPMEventLogEntry{
+		PCRIndex: pcrIndex,
+		HashAlgo: hashAlgo,
+		Digest:   digest,
+		Data:     data,
+	})
+}

--- a/pkg/bootflow/types/_autodocs.go
+++ b/pkg/bootflow/types/_autodocs.go
@@ -9,6 +9,7 @@ type State struct {
 	SystemArtifacts
 	TrustChains
 	Flow
+	VerifiedData
 }
 
 type Data struct {

--- a/pkg/bootflow/types/_autodocs.go
+++ b/pkg/bootflow/types/_autodocs.go
@@ -1,0 +1,26 @@
+//go:build none
+// +build none
+
+package types
+
+// This files is used only to provide hints to the "goplantuml" tool
+
+type State struct {
+	SystemArtifacts
+	TrustChains
+	Flow
+}
+
+type Data struct {
+	References
+	pkgbytes.Ranges
+}
+
+type Reference struct {
+	types.SystemArtifact
+}
+
+type VerifiedData struct {
+	Data Data
+	TrustChain
+}

--- a/pkg/bootflow/types/data.go
+++ b/pkg/bootflow/types/data.go
@@ -12,6 +12,13 @@ type Data struct {
 	References References
 }
 
+func (d Data) GoString() string {
+	if d.ForceBytes != nil {
+		return fmt.Sprintf("{ForceBytes: %X}", d.ForceBytes)
+	}
+	return fmt.Sprintf("{Refs: %#v}", d.References)
+}
+
 func (d *Data) Bytes() []byte {
 	if d.ForceBytes != nil && d.References != nil {
 		panic("Data is supposed to be used as union")
@@ -39,6 +46,10 @@ type Reference struct {
 	Ranges   pkgbytes.Ranges
 }
 
+func (ref Reference) GoString() string {
+	return fmt.Sprintf("%T:%#v", ref.Artifact, ref.Ranges)
+}
+
 func (ref *Reference) Bytes() []byte {
 	totalLength := uint64(0)
 	ranges := ref.Ranges
@@ -64,4 +75,8 @@ func (ref *Reference) Bytes() []byte {
 type VerifiedData struct {
 	Data
 	TrustChain TrustChain
+}
+
+func (d VerifiedData) GoString() string {
+	return fmt.Sprintf("%s: %#v", typeMapKey(d.TrustChain).Name(), d.Data)
 }

--- a/pkg/bootflow/types/data.go
+++ b/pkg/bootflow/types/data.go
@@ -1,0 +1,67 @@
+package types
+
+import (
+	"bytes"
+	"fmt"
+
+	pkgbytes "github.com/linuxboot/fiano/pkg/bytes"
+)
+
+type Data struct {
+	ForceBytes []byte
+	References References
+}
+
+func (d *Data) Bytes() []byte {
+	if d.ForceBytes != nil && d.References != nil {
+		panic("Data is supposed to be used as union")
+	}
+	if d.ForceBytes != nil {
+		return d.ForceBytes
+	}
+	return d.References.Bytes()
+}
+
+type References []Reference
+
+func (s References) Bytes() []byte {
+	var buf bytes.Buffer
+	for _, ref := range s {
+		if _, err := buf.Write(ref.Bytes()); err != nil {
+			panic(err)
+		}
+	}
+	return buf.Bytes()
+}
+
+type Reference struct {
+	Artifact SystemArtifact
+	Ranges   pkgbytes.Ranges
+}
+
+func (ref *Reference) Bytes() []byte {
+	totalLength := uint64(0)
+	ranges := ref.Ranges
+	ranges.SortAndMerge()
+	for _, r := range ranges {
+		totalLength += r.Length
+	}
+
+	result := make([]byte, totalLength)
+	curPos := uint64(0)
+	for _, r := range ranges {
+		n, err := ref.Artifact.ReadAt(result[curPos:curPos+r.Length], int64(r.Offset))
+		if err != nil {
+			panic(err)
+		}
+		if n != int(r.Length) {
+			panic(fmt.Errorf("unexpected read size: expected:%d actual:%d", r.Length, n))
+		}
+	}
+	return result
+}
+
+type VerifiedData struct {
+	Data
+	TrustChain TrustChain
+}

--- a/pkg/bootflow/types/errors.go
+++ b/pkg/bootflow/types/errors.go
@@ -1,0 +1,38 @@
+package types
+
+import (
+	"fmt"
+	"reflect"
+)
+
+type ErrNoTrustChain struct {
+	TrustChainKey reflect.Type
+}
+
+func (err ErrNoTrustChain) Error() string {
+	return fmt.Sprintf("no trust chain of type %T found", err.TrustChainKey)
+}
+
+func (err ErrNoTrustChain) TrustChainTypeIs(sample TrustChain) bool {
+	return err.TrustChainKey == typeMapKey(sample)
+}
+
+func (err ErrNoTrustChain) GoString() string {
+	return fmt.Sprintf("ErrNoTrustChain{%s}", err.TrustChainKey.Name())
+}
+
+type ErrNoSystemArtifact struct {
+	SystemArtifactKey reflect.Type
+}
+
+func (err ErrNoSystemArtifact) Error() string {
+	return fmt.Sprintf("no system artifact of type %T found", err.SystemArtifactKey)
+}
+
+func (err ErrNoSystemArtifact) ErrNoSystemArtifactTypeIs(sample SystemArtifact) bool {
+	return err.SystemArtifactKey == typeMapKey(sample)
+}
+
+func (err ErrNoSystemArtifact) GoString() string {
+	return fmt.Sprintf("ErrNoSystemArtifact{%s}", err.SystemArtifactKey.Name())
+}

--- a/pkg/bootflow/types/flow.go
+++ b/pkg/bootflow/types/flow.go
@@ -1,0 +1,29 @@
+package types
+
+// Flow describes steps of the boot process.
+//
+// A flow is static (never change).
+type Flow []Step
+
+// Stop describes a single step of a boot process, essential for the measurements.
+// Steps of a flow may vary depending on a State.
+//
+// An example: measure specific sections in an AMD Manifest
+type Step interface {
+	Actions(*State) Actions
+}
+
+type StaticStep Actions
+
+func (step StaticStep) Actions(*State) Actions {
+	return Actions(step)
+}
+
+type Actions []Action
+
+// Describes a single event happening during some boot step.
+//
+// An example: measure a specific section in an AMD Manifest
+type Action interface {
+	Apply(*State) error
+}

--- a/pkg/bootflow/types/state.go
+++ b/pkg/bootflow/types/state.go
@@ -83,7 +83,7 @@ func (state *State) EnableSystemArtifact(systemArtifact SystemArtifact) {
 
 	k := typeMapKey(systemArtifact)
 	if _, ok := state.SystemArtifacts[k]; ok {
-		panic(fmt.Sprintf("double-setting of the same trust chain type: %s", k))
+		panic(fmt.Sprintf("double-setting of the same system artifact type: %s", k))
 	}
 	state.SystemArtifacts[k] = systemArtifact
 }

--- a/pkg/bootflow/types/state.go
+++ b/pkg/bootflow/types/state.go
@@ -1,7 +1,16 @@
 package types
 
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
 // State describes a virtual state of a machine being booted
 type State struct {
+	// Do not mutate these values from the outside, the mutability
+	// is owned by State itself.
+
 	SystemArtifacts SystemArtifacts
 	TrustChains     TrustChains
 	CurrentFlow     Flow
@@ -9,13 +18,108 @@ type State struct {
 	VerifiedData    []VerifiedData
 }
 
-func (state *State) AddVerifiedData(trustChain TrustChain, data Data) {
-	if data.ForceBytes != nil {
-		return
+func typeMapKey(i interface{}) reflect.Type {
+	k := reflect.TypeOf(i)
+	for k.Kind() == reflect.Ptr {
+		k = k.Elem()
+	}
+	return k
+}
+
+func NewState() *State {
+	return &State{
+		SystemArtifacts: map[reflect.Type]SystemArtifact{},
+		TrustChains:     map[reflect.Type]TrustChain{},
+	}
+}
+
+func (state *State) SetFlow(flow Flow, stepIdx uint) {
+	state.CurrentFlow = flow
+	state.CurrentStepIdx = stepIdx
+}
+
+func (state *State) TrustChainExec(
+	trustChainSample TrustChain,
+	callback func(trustChain TrustChain) error,
+) error {
+	key := typeMapKey(trustChainSample)
+	trustChain := state.TrustChains[key]
+	if trustChain == nil {
+		return ErrNoTrustChain{TrustChainKey: key}
 	}
 
+	return callback(trustChain)
+}
+
+func (state *State) EnableTrustChain(trustChain TrustChain) {
+	if reflect.TypeOf(trustChain).Kind() != reflect.Ptr {
+		panic(fmt.Sprintf("%T is not a modifiable type", trustChain))
+	}
+
+	k := typeMapKey(trustChain)
+	if _, ok := state.TrustChains[k]; ok {
+		panic(fmt.Sprintf("double-setting of the same trust chain type: %s", k))
+	}
+	state.TrustChains[k] = trustChain
+}
+
+func (state *State) SystemArtifactExec(
+	systemArtifactSample SystemArtifact,
+	callback func(systemArtifact SystemArtifact) error,
+) error {
+	key := typeMapKey(systemArtifactSample)
+	systemArtifact := state.SystemArtifacts[key]
+	if systemArtifact == nil {
+		return ErrNoSystemArtifact{SystemArtifactKey: key}
+	}
+
+	return callback(systemArtifact)
+}
+
+func (state *State) EnableSystemArtifact(systemArtifact SystemArtifact) {
+	if reflect.TypeOf(systemArtifact).Kind() != reflect.Ptr {
+		panic(fmt.Sprintf("%T is not a modifiable type", systemArtifact))
+	}
+
+	k := typeMapKey(systemArtifact)
+	if _, ok := state.SystemArtifacts[k]; ok {
+		panic(fmt.Sprintf("double-setting of the same trust chain type: %s", k))
+	}
+	state.SystemArtifacts[k] = systemArtifact
+}
+
+func (state *State) AddVerifiedData(trustChain TrustChain, data Data) {
 	state.VerifiedData = append(state.VerifiedData, VerifiedData{
 		Data:       data,
 		TrustChain: trustChain,
 	})
+}
+
+func (state *State) GoString() string {
+	var result strings.Builder
+	if len(state.SystemArtifacts) > 0 {
+		fmt.Fprintf(&result, "SystemArtifacts:\n\t%s\n", nestedGoStringOf(state.SystemArtifacts))
+	}
+	if len(state.TrustChains) > 0 {
+		fmt.Fprintf(&result, "TrustChains:\n\t%s\n", nestedGoStringOf(state.TrustChains))
+	}
+	if len(state.CurrentFlow) > 0 {
+		fmt.Fprintf(&result, "CurrentFlow:\n\t%s\n", nestedGoStringOf(state.CurrentFlow))
+		fmt.Fprintf(&result, "CurrentStepIndex: %d\n", state.CurrentStepIdx)
+	}
+	if len(state.VerifiedData) > 0 {
+		fmt.Fprintf(&result, "VerifiedData:\n\t%s\n", nestedGoStringOf(state.VerifiedData))
+	}
+	return result.String()
+}
+
+func (state *State) GetVerifiedDataBy(trustChainSample TrustChain) []VerifiedData {
+	var result []VerifiedData
+	cmpKey := typeMapKey(trustChainSample)
+	for _, verifiedData := range state.VerifiedData {
+		if typeMapKey(verifiedData.TrustChain) == cmpKey {
+			result = append(result, verifiedData)
+		}
+	}
+	return result
 }

--- a/pkg/bootflow/types/state.go
+++ b/pkg/bootflow/types/state.go
@@ -1,0 +1,21 @@
+package types
+
+// State describes a virtual state of a machine being booted
+type State struct {
+	SystemArtifacts SystemArtifacts
+	TrustChains     TrustChains
+	CurrentFlow     Flow
+	CurrentStepIdx  uint
+	VerifiedData    []VerifiedData
+}
+
+func (state *State) AddVerifiedData(trustChain TrustChain, data Data) {
+	if data.ForceBytes != nil {
+		return
+	}
+
+	state.VerifiedData = append(state.VerifiedData, VerifiedData{
+		Data:       data,
+		TrustChain: trustChain,
+	})
+}

--- a/pkg/bootflow/types/system_artifact.go
+++ b/pkg/bootflow/types/system_artifact.go
@@ -1,0 +1,12 @@
+package types
+
+import (
+	"io"
+)
+
+type SystemArtifacts []SystemArtifact
+
+type SystemArtifact interface {
+	io.ReaderAt // should never return an error
+	Size() uint
+}

--- a/pkg/bootflow/types/system_artifact.go
+++ b/pkg/bootflow/types/system_artifact.go
@@ -1,12 +1,28 @@
 package types
 
 import (
+	"fmt"
 	"io"
+	"reflect"
+	"strings"
 )
 
-type SystemArtifacts []SystemArtifact
+type SystemArtifacts map[reflect.Type]SystemArtifact
 
 type SystemArtifact interface {
 	io.ReaderAt // should never return an error
 	Size() uint
+}
+
+func (m SystemArtifacts) GoString() string {
+	var result strings.Builder
+	for k, artifact := range m {
+		fmt.Fprintf(&result, "%s:\n\t%s\n", k.Name(), nestedGoStringOf(artifact))
+	}
+	return result.String()
+}
+
+func nestedGoStringOf(i interface{}) string {
+	v := fmt.Sprintf("%#v", i)
+	return strings.ReplaceAll(strings.Trim(v, "\n"), "\n", "\n\t")
 }

--- a/pkg/bootflow/types/trust_chain.go
+++ b/pkg/bootflow/types/trust_chain.go
@@ -1,0 +1,7 @@
+package types
+
+type TrustChains []TrustChain
+
+type TrustChain interface {
+	IsInitialized() bool
+}

--- a/pkg/bootflow/types/trust_chain.go
+++ b/pkg/bootflow/types/trust_chain.go
@@ -1,7 +1,21 @@
 package types
 
-type TrustChains []TrustChain
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+type TrustChains map[reflect.Type]TrustChain
 
 type TrustChain interface {
 	IsInitialized() bool
+}
+
+func (m TrustChains) GoString() string {
+	var result strings.Builder
+	for k, artifact := range m {
+		fmt.Fprintf(&result, "%s:\n\t%s\n", k.Name(), nestedGoStringOf(artifact))
+	}
+	return result.String()
 }


### PR DESCRIPTION
Adding the main entities of a new design of PCR values calculations process. New package is called "bootflow" (instead of "pcr"), since it is not longer focused on PCR values only. It also supports other roots of trust for storage and measurements.

New design (in contrast to the old one) is:
* Extensible from external packages.
* TPM terms "Event", "Extend" and "Measurement" are clarified.
* Flow now consists of steps. Each step may contain multiple measurements. It solves the problem with dynamic amount of measurements on some platforms.
* New design also aware of DICE and other chains of trust.

![uml](https://user-images.githubusercontent.com/2349376/170550142-d2b1555d-2a6c-4c15-9d6e-7d5742ee9199.png)


UML is generated by command:
```
goplantuml -recursive pkg/bootflow/ | sed -e 's/\#\.\./\*--/g' | sed -re 's/\[\]([^b])/\1/g'
```

An example of a flow description:
https://github.com/9elements/converged-security-suite/pull/330/files#diff-27af1a8ff010eb439ee11da802024b19fbf9bf11ea6580efcbfed47f54135c89R9-R15