### PR TITLE
feat(pkg/uefi): Add a field to adjust the offset

### DIFF
--- a/pkg/uefi/ffs/node.go
+++ b/pkg/uefi/ffs/node.go
@@ -9,6 +9,12 @@ import (
 type Node struct {
 	fianoUEFI.Firmware
 	pkgbytes.Range
+
+	// AddOffset adds the value to all offsets.
+	// It, for example, affects GetByRange accordingly.
+	//
+	// It does effect only if a method of this node directly is used.
+	AddOffset int64
 }
 
 func (node Node) GUID() *fianoGUID.GUID {

--- a/pkg/uefi/ffs/node_get_by_range_test.go
+++ b/pkg/uefi/ffs/node_get_by_range_test.go
@@ -1,0 +1,37 @@
+package ffs_test
+
+import (
+	"testing"
+
+	"github.com/9elements/converged-security-suite/v2/pkg/uefi"
+	"github.com/9elements/converged-security-suite/v2/testdata/firmware"
+	pkgbytes "github.com/linuxboot/fiano/pkg/bytes"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNodeGetNamesByRange(t *testing.T) {
+	t.Run("simple", func(t *testing.T) {
+		fw, err := uefi.ParseUEFIFirmwareBytes(firmware.FakeIntelFirmware)
+		assert.NoError(t, err)
+
+		nodes, err := fw.GetByRange(pkgbytes.Range{
+			Offset: 0,
+			Length: 1,
+		})
+		assert.NoError(t, err)
+		assert.Len(t, nodes, 2)
+	})
+
+	t.Run("with_offset", func(t *testing.T) {
+		fw, err := uefi.ParseUEFIFirmwareBytes(firmware.FakeIntelFirmware)
+		assert.NoError(t, err)
+
+		fw.AddOffset = 1 << 30
+		nodes, err := fw.GetByRange(pkgbytes.Range{
+			Offset: 1 << 30,
+			Length: 1,
+		})
+		assert.NoError(t, err)
+		assert.Len(t, nodes, 2)
+	})
+}


### PR DESCRIPTION
Sometimes it is required to do calculations relatively to specific region or volume. But when we parse an UEFI image a component stores the offset inside and we want to avoid reparsing an image (it is expensive). So we add this hack which adjusts offsets without reparsing the image.