### PR TITLE
Handle misaligned TPM EventLog propertly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,12 +6,12 @@ jobs:
   build:
     docker:
       # specify the version
-      - image: circleci/golang:latest
+      - image: golang:1.18
 
     working_directory: /go/src/github.com/9elements/converged-security-suite
     steps:
       - checkout
-      - run: sudo apt install -y golint
+      - run: apt update && apt install -y golint
       # specify any bash command here prefixed with `run: `
       - run: if [ "$(gofmt -l .)" != "" ]; then exit 1; fi
       - run: golint -set_exit_status ./cmd/txt-suite
@@ -23,7 +23,7 @@ jobs:
       - run: CGO_ENABLED=0 go build -ldflags '-X main.gitcommit=${CIRCLE_SHA1} -X main.gittag=${CIRCLE_TAG} -w -extldflags "-static"' -o txt-prov cmd/txt-prov/*.go
       - run: CGO_ENABLED=0 go build -ldflags '-X main.gitcommit=${CIRCLE_SHA1} -X main.gittag=${CIRCLE_TAG} -w -extldflags "-static"' -o cbnt-prov cmd/cbnt-prov/*.go
       - run: go test ./pkg/check/
-      - run: sudo apt-get update && sudo apt-get install libtspi-dev && go test ./pkg/diff/
+      - run: apt install -y libtspi-dev && go test ./pkg/diff/
       - run: go test ./pkg/errors/
       - run: go test ./pkg/hwapi/
       - run: go test ./pkg/mathtools/
@@ -56,7 +56,7 @@ jobs:
   create_deb_rpm:
     docker:
       # specify the version
-      - image: circleci/golang:1.13
+      - image: golang:1.18
 
     working_directory: /go/src/github.com/9elements/converged-security-suite
     steps:
@@ -96,7 +96,7 @@ jobs:
   build_arm:
     docker:
       # specify the version
-      - image: circleci/golang:1.13
+      - image: golang:1.18
 
     working_directory: /go/src/github.com/9elements/converged-security-suite
     steps:
@@ -110,7 +110,7 @@ jobs:
   build_arm64:
     docker:
       # specify the version
-      - image: circleci/golang:1.13
+      - image: golang:1.18
 
     working_directory: /go/src/github.com/9elements/converged-security-suite
     steps:
@@ -124,7 +124,7 @@ jobs:
   build_ppc64le:
     docker:
       # specify the version
-      - image: circleci/golang:1.13
+      - image: golang:1.18
 
     working_directory: /go/src/github.com/9elements/converged-security-suite
     steps:

--- a/cmd/cbnt-prov/cmd.go
+++ b/cmd/cbnt-prov/cmd.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/linuxboot/fiano/pkg/intel/metadata/fit"
@@ -229,7 +228,7 @@ func (v *versionCmd) Run(ctx *context) error {
 }
 
 func (kmp *kmPrintCmd) Run(ctx *context) error {
-	data, err := ioutil.ReadFile(kmp.Path)
+	data, err := os.ReadFile(kmp.Path)
 	if err != nil {
 		return err
 	}
@@ -257,7 +256,7 @@ func (kmp *kmPrintCmd) Run(ctx *context) error {
 }
 
 func (bpmp *bpmPrintCmd) Run(ctx *context) error {
-	data, err := ioutil.ReadFile(bpmp.Path)
+	data, err := os.ReadFile(bpmp.Path)
 	if err != nil {
 		return err
 	}
@@ -285,7 +284,7 @@ func (bpmp *bpmPrintCmd) Run(ctx *context) error {
 }
 
 func (acmp *acmPrintCmd) Run(ctx *context) error {
-	data, err := ioutil.ReadFile(acmp.Path)
+	data, err := os.ReadFile(acmp.Path)
 	if err != nil {
 		return err
 	}
@@ -308,7 +307,7 @@ func (acmp *acmPrintCmd) Run(ctx *context) error {
 }
 
 func (biosp *biosPrintCmd) Run(ctx *context) error {
-	data, err := ioutil.ReadFile(biosp.Path)
+	data, err := os.ReadFile(biosp.Path)
 	if err != nil {
 		return err
 	}
@@ -325,7 +324,7 @@ func (biosp *biosPrintCmd) Run(ctx *context) error {
 }
 
 func (acme *acmExportCmd) Run(ctx *context) error {
-	data, err := ioutil.ReadFile(acme.BIOS)
+	data, err := os.ReadFile(acme.BIOS)
 	if err != nil {
 		return err
 	}
@@ -341,7 +340,7 @@ func (acme *acmExportCmd) Run(ctx *context) error {
 }
 
 func (kme *kmExportCmd) Run(ctx *context) error {
-	data, err := ioutil.ReadFile(kme.BIOS)
+	data, err := os.ReadFile(kme.BIOS)
 	if err != nil {
 		return err
 	}
@@ -357,7 +356,7 @@ func (kme *kmExportCmd) Run(ctx *context) error {
 }
 
 func (bpme *bpmExportCmd) Run(ctx *context) error {
-	data, err := ioutil.ReadFile(bpme.BIOS)
+	data, err := os.ReadFile(bpme.BIOS)
 	if err != nil {
 		return err
 	}
@@ -444,7 +443,7 @@ func (g *generateKMCmd) Run(ctx *context) error {
 		//Cut signature from binary
 		bKM = bKM[:int(options.KeyManifest.KeyManifestSignatureOffset)]
 	}
-	if err = ioutil.WriteFile(g.KM, bKM, 0600); err != nil {
+	if err = os.WriteFile(g.KM, bKM, 0600); err != nil {
 		return fmt.Errorf("unable to write KM to file: %w", err)
 	}
 	return nil
@@ -544,7 +543,7 @@ func (g *generateBPMCmd) Run(ctx *context) error {
 	if g.Cut {
 		bBPM = bBPM[:bpm.KeySignatureOffset]
 	}
-	if err = ioutil.WriteFile(g.BPM, bBPM, 0600); err != nil {
+	if err = os.WriteFile(g.BPM, bBPM, 0600); err != nil {
 		return fmt.Errorf("unable to write BPM to file: %w", err)
 	}
 	return nil
@@ -603,7 +602,7 @@ func (g *generateACMCmd) Run(ctx *context) error {
 		EntrySACMDataInterface: config.ACMHeaders,
 	}
 	if g.BodyPath != "" {
-		bodyData, err := ioutil.ReadFile(g.BodyPath)
+		bodyData, err := os.ReadFile(g.BodyPath)
 		if err != nil {
 			return fmt.Errorf("unable to read the ACM body file '%s': %w", g.BodyPath, err)
 		}
@@ -620,14 +619,14 @@ func (g *generateACMCmd) Run(ctx *context) error {
 		return fmt.Errorf("unable to compile the ACM module: %w", err)
 	}
 
-	if err = ioutil.WriteFile(g.ACMOut, acmBytes.Bytes(), 0600); err != nil {
+	if err = os.WriteFile(g.ACMOut, acmBytes.Bytes(), 0600); err != nil {
 		return fmt.Errorf("unable to write KM to file: %w", err)
 	}
 	return nil
 }
 
 func (s *signKMCmd) Run(ctx *context) error {
-	encKey, err := ioutil.ReadFile(s.Key)
+	encKey, err := os.ReadFile(s.Key)
 	if err != nil {
 		return err
 	}
@@ -635,7 +634,7 @@ func (s *signKMCmd) Run(ctx *context) error {
 	if err != nil {
 		return err
 	}
-	kmRaw, err := ioutil.ReadFile(s.KmIn)
+	kmRaw, err := os.ReadFile(s.KmIn)
 	if err != nil {
 		return err
 	}
@@ -658,14 +657,14 @@ func (s *signKMCmd) Run(ctx *context) error {
 	if err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(s.KmOut, bKMSigned, 0600); err != nil {
+	if err := os.WriteFile(s.KmOut, bKMSigned, 0600); err != nil {
 		return err
 	}
 	return nil
 }
 
 func (s *signBPMCmd) Run(ctx *context) error {
-	encKey, err := ioutil.ReadFile(s.Key)
+	encKey, err := os.ReadFile(s.Key)
 	if err != nil {
 		return err
 	}
@@ -673,7 +672,7 @@ func (s *signBPMCmd) Run(ctx *context) error {
 	if err != nil {
 		return err
 	}
-	bpmRaw, err := ioutil.ReadFile(s.BpmIn)
+	bpmRaw, err := os.ReadFile(s.BpmIn)
 	if err != nil {
 		return err
 	}
@@ -712,7 +711,7 @@ func (s *signBPMCmd) Run(ctx *context) error {
 	if err != nil {
 		return err
 	}
-	if err = ioutil.WriteFile(s.BpmOut, bBPMSigned, 0600); err != nil {
+	if err = os.WriteFile(s.BpmOut, bBPMSigned, 0600); err != nil {
 		return fmt.Errorf("unable to write BPM to file: %w", err)
 	}
 	return nil
@@ -789,11 +788,11 @@ func (rc *readConfigCmd) Run(ctx *context) error {
 }
 
 func (s *stitchingKMCmd) Run(ctx *context) error {
-	kmData, err := ioutil.ReadFile(s.KM)
+	kmData, err := os.ReadFile(s.KM)
 	if err != nil {
 		return err
 	}
-	sig, err := ioutil.ReadFile(s.Signature)
+	sig, err := os.ReadFile(s.Signature)
 	if err != nil {
 		return err
 	}
@@ -813,18 +812,18 @@ func (s *stitchingKMCmd) Run(ctx *context) error {
 	if err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(s.Out, kmRaw, 0644); err != nil {
+	if err := os.WriteFile(s.Out, kmRaw, 0644); err != nil {
 		return err
 	}
 	return nil
 }
 
 func (s *stitchingBPMCmd) Run(ctx *context) error {
-	bpmData, err := ioutil.ReadFile(s.BPM)
+	bpmData, err := os.ReadFile(s.BPM)
 	if err != nil {
 		return err
 	}
-	sig, err := ioutil.ReadFile(s.Signature)
+	sig, err := os.ReadFile(s.Signature)
 	if err != nil {
 		return err
 	}
@@ -844,7 +843,7 @@ func (s *stitchingBPMCmd) Run(ctx *context) error {
 	if err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(s.Out, bpmRaw, 0644); err != nil {
+	if err := os.WriteFile(s.Out, bpmRaw, 0644); err != nil {
 		return err
 	}
 	return nil
@@ -854,22 +853,22 @@ func (s *stitchingCmd) Run(ctx *context) error {
 	var err error
 	var bpm, km, acm, me []byte
 	if s.BPM != "" {
-		if bpm, err = ioutil.ReadFile(s.BPM); err != nil {
+		if bpm, err = os.ReadFile(s.BPM); err != nil {
 			return err
 		}
 	}
 	if s.KM != "" {
-		if km, err = ioutil.ReadFile(s.KM); err != nil {
+		if km, err = os.ReadFile(s.KM); err != nil {
 			return err
 		}
 	}
 	if s.ACM != "" {
-		if acm, err = ioutil.ReadFile(s.ACM); err != nil {
+		if acm, err = os.ReadFile(s.ACM); err != nil {
 			return err
 		}
 	}
 	if s.ME != "" {
-		if me, err = ioutil.ReadFile(s.ME); err != nil {
+		if me, err = os.ReadFile(s.ME); err != nil {
 			return err
 		}
 	}
@@ -880,7 +879,7 @@ func (s *stitchingCmd) Run(ctx *context) error {
 		return err
 	}
 	if len(me) != 0 {
-		image, err := ioutil.ReadFile(s.BIOS)
+		image, err := os.ReadFile(s.BIOS)
 		if err != nil {
 			return err
 		}
@@ -954,7 +953,7 @@ func (k *keygenCmd) Run(ctx *context) error {
 }
 
 func (p printFITCmd) Run(ctx *context) error {
-	img, err := ioutil.ReadFile(p.BIOS)
+	img, err := os.ReadFile(p.BIOS)
 	if err != nil {
 		return err
 	}
@@ -967,7 +966,7 @@ func (p printFITCmd) Run(ctx *context) error {
 }
 
 func (v *verifyKMSigCmd) Run(ctx *context) error {
-	kmRaw, err := ioutil.ReadFile(v.KM)
+	kmRaw, err := os.ReadFile(v.KM)
 	if err != nil {
 		return err
 	}
@@ -985,7 +984,7 @@ func (v *verifyKMSigCmd) Run(ctx *context) error {
 }
 
 func (b *verifyBPMSigCmd) Run(ctx *context) error {
-	bpmraw, err := ioutil.ReadFile(b.BPM)
+	bpmraw, err := os.ReadFile(b.BPM)
 	if err != nil {
 		return err
 	}

--- a/cmd/pcr0tool/commands/displayfwinfo/command.go
+++ b/cmd/pcr0tool/commands/displayfwinfo/command.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/9elements/converged-security-suite/v2/pkg/dmidecode"
@@ -54,7 +53,7 @@ func (cmd Command) Execute(args []string) {
 	}
 	imagePath := args[0]
 
-	imageBytes, err := ioutil.ReadFile(imagePath)
+	imageBytes, err := os.ReadFile(imagePath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "unable to read image '%s': %v", imagePath, err)
 		return

--- a/cmd/pcr0tool/commands/dumpregisters/command.go
+++ b/cmd/pcr0tool/commands/dumpregisters/command.go
@@ -3,7 +3,7 @@ package dumpregisters
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/9elements/converged-security-suite/v2/cmd/pcr0tool/commands/dumpregisters/helpers"
 	"github.com/9elements/converged-security-suite/v2/pkg/registers"
@@ -69,7 +69,7 @@ func (cmd Command) Execute(args []string) {
 		if err != nil {
 			panic(fmt.Sprintf("failed to marshal registers into json, err: %v", err))
 		}
-		err = ioutil.WriteFile(*cmd.outputFile, b, 0666)
+		err = os.WriteFile(*cmd.outputFile, b, 0666)
 		if err != nil {
 			panic(fmt.Sprintf("failed to write data to file %s, err: %v", *cmd.outputFile, err))
 		}

--- a/cmd/pcr0tool/commands/dumpregisters/helpers/flag_registers.go
+++ b/cmd/pcr0tool/commands/dumpregisters/helpers/flag_registers.go
@@ -3,7 +3,7 @@ package helpers
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/9elements/converged-security-suite/v2/pkg/registers"
 	"gopkg.in/yaml.v3"
@@ -36,7 +36,7 @@ func (f *FlagRegisters) Set(in string) error {
 		*f = FlagRegisters(regs)
 		return nil
 	default:
-		contents, err := ioutil.ReadFile(in)
+		contents, err := os.ReadFile(in)
 		if err != nil {
 			return fmt.Errorf("unable to parse file '%s': %w", in, err)
 		}

--- a/cmd/pcr0tool/commands/dumpregisters/helpers/get_registers.go
+++ b/cmd/pcr0tool/commands/dumpregisters/helpers/get_registers.go
@@ -2,7 +2,7 @@ package helpers
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"runtime"
 
 	"github.com/9elements/converged-security-suite/v2/pkg/errors"
@@ -77,7 +77,7 @@ func GetRegisters(options ...GetRegistersOption) (registers.Registers, error) {
 
 func getTXTConfig(cfg getRegistersConfig) (registers.TXTConfigSpace, error) {
 	if cfg.OverrideTXTPublic != "" {
-		b, err := ioutil.ReadFile(cfg.OverrideTXTPublic)
+		b, err := os.ReadFile(cfg.OverrideTXTPublic)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read TXT public space from '%s': %w", cfg.OverrideTXTPublic, err)
 		}

--- a/cmd/pcr0tool/commands/sum/command.go
+++ b/cmd/pcr0tool/commands/sum/command.go
@@ -172,8 +172,8 @@ func (cmd Command) Execute(args []string) {
 		assertNoError(err)
 		tpmEventLog, err := tpmeventlog.Parse(f)
 		assertNoError(err)
-		match, updatedACMPolicyStatus, err := pcrbruteforcer.ReproduceEventLog(tpmEventLog, tpmeventlog.TPMAlgorithmSHA1, measurements, firmware.Buf(), pcrbruteforcer.DefaultSettingsReproduceEventLog())
-		fmt.Printf("comparing with TPM EventLog result:\n\tmatch: %v\n\tupdated ACM Policy Status: %v\n\terr: %v\n",
-			match, updatedACMPolicyStatus, err)
+		match, updatedACMPolicyStatus, issues, err := pcrbruteforcer.ReproduceEventLog(tpmEventLog, tpmeventlog.TPMAlgorithmSHA1, measurements, firmware.Buf(), pcrbruteforcer.DefaultSettingsReproduceEventLog())
+		fmt.Printf("comparing with TPM EventLog result:\n\tmatch: %v\n\tupdated ACM Policy Status: %v\n\terr: %v\n\tissues: %v\n",
+			match, updatedACMPolicyStatus, err, issues)
 	}
 }

--- a/cmd/pcr0tool/commands/sum/command.go
+++ b/cmd/pcr0tool/commands/sum/command.go
@@ -172,7 +172,7 @@ func (cmd Command) Execute(args []string) {
 		assertNoError(err)
 		tpmEventLog, err := tpmeventlog.Parse(f)
 		assertNoError(err)
-		match, updatedACMPolicyStatus, err := pcrbruteforcer.ReproduceEventLog(tpmEventLog, measurements, firmware.Buf())
+		match, updatedACMPolicyStatus, err := pcrbruteforcer.ReproduceEventLog(tpmEventLog, tpmeventlog.TPMAlgorithmSHA1, measurements, firmware.Buf(), pcrbruteforcer.DefaultSettingsReproduceEventLog())
 		fmt.Printf("comparing with TPM EventLog result:\n\tmatch: %v\n\tupdated ACM Policy Status: %v\n\terr: %v\n",
 			match, updatedACMPolicyStatus, err)
 	}

--- a/cmd/txt-prov/config.go
+++ b/cmd/txt-prov/config.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -33,7 +33,7 @@ func loadConfig(filename string) (*tools.LCPPolicy2, error) {
 	var ok bool
 	var b []byte
 	var config configJSON
-	b, err := ioutil.ReadFile(filename)
+	b, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/txt-prov/tools.go
+++ b/cmd/txt-prov/tools.go
@@ -5,7 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/9elements/converged-security-suite/v2/pkg/tools"
@@ -37,7 +37,7 @@ func writePSPolicy2file(policy *tools.LCPPolicy2, filename string) error {
 	if err != nil {
 		return err
 	}
-	if err = ioutil.WriteFile(filename, buf.Bytes(), 0600); err != nil {
+	if err = os.WriteFile(filename, buf.Bytes(), 0600); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/txt-suite/cmd.go
+++ b/cmd/txt-suite/cmd.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 
@@ -188,7 +187,7 @@ func run(testGroup string, tests []*test.Test, config tools.Configuration, inter
 			}
 		}
 		data, _ := json.MarshalIndent(t, "", "")
-		ioutil.WriteFile(logfile, data, 0664)
+		os.WriteFile(logfile, data, 0664)
 	}
 
 	for index := range tests {

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
 module github.com/9elements/converged-security-suite/v2
 
-go 1.13
+go 1.18
 
 require (
-	github.com/9elements/converged-security-suite/v2/testdata/firmware v0.0.0-00010101000000-000000000000
 	github.com/9elements/go-linux-lowlevel-hw v0.0.0-20211215141225-8375dd201aae
 	github.com/alecthomas/kong v0.2.11
 	github.com/creasty/defaults v1.5.1
@@ -16,7 +15,6 @@ require (
 	github.com/google/go-tpm v0.3.3-0.20210120190357-1ff48daca32f
 	github.com/google/uuid v1.3.0
 	github.com/klauspost/cpuid/v2 v2.0.9
-	github.com/kr/pretty v0.2.1 // indirect
 	github.com/linuxboot/contest v0.0.0-20220404120719-d952dfa563c4
 	github.com/linuxboot/fiano v1.1.1-0.20220414102525-737513644344
 	github.com/logrusorgru/aurora v2.0.3+incompatible
@@ -33,4 +31,28 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
 
-replace github.com/9elements/converged-security-suite/v2/testdata/firmware => ./testdata/firmware
+require (
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/godbus/dbus/v5 v5.0.4 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/certificate-transparency-go v1.1.1 // indirect
+	github.com/google/go-tspi v0.2.1-0.20190423175329-115dea689aad // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/intel-go/cpuid v0.0.0-20200819041909-2aa72927c3e2 // indirect
+	github.com/kr/pretty v0.2.1 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_golang v1.11.0 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.32.1 // indirect
+	github.com/prometheus/procfs v0.7.3 // indirect
+	github.com/sirupsen/logrus v1.8.1 // indirect
+	golang.org/x/sys v0.0.0-20211031064116-611d5d643895 // indirect
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
+	golang.org/x/text v0.3.6 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -78,7 +78,6 @@ github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN
 github.com/aws/aws-sdk-go v1.41.14/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/beevik/ntp v0.3.0/go.mod h1:hIHWr+l3+/clUnF44zdK+CWW7fO8dR5cIylAQ76NRpg=
-github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -90,7 +89,6 @@ github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.0.2/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8Bog/87DQnVg=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
@@ -650,7 +648,6 @@ go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
-go.uber.org/goleak v1.1.11-0.20210813005559-691160354723 h1:sHOAIxRGBp443oHZIPB+HsUGaksVCXVQENPxwTfQdH4=
 go.uber.org/goleak v1.1.11-0.20210813005559-691160354723/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
@@ -702,7 +699,6 @@ golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
-golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
@@ -712,7 +708,6 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -926,7 +921,6 @@ golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200915201639-f4cefd1cb5ba/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools v0.1.5 h1:ouewzE6p+/VEB31YYnTbEJdi8pFqKp4P4n85vwo3DHA=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -1052,7 +1046,6 @@ gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.6/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=

--- a/pkg/bruteforcer/brute_forcer.go
+++ b/pkg/bruteforcer/brute_forcer.go
@@ -187,7 +187,7 @@ func run[E Item, T Slice[E]](b *bruteForcer[E, T], itemSize uint64, maxDistance 
 
 		var errors errors.MultiError
 		for err := range errChan {
-			errors.Add(err)
+			_ = errors.Add(err)
 		}
 
 		if len(errors) > 0 {

--- a/pkg/bruteforcer/brute_forcer.go
+++ b/pkg/bruteforcer/brute_forcer.go
@@ -14,43 +14,73 @@ const (
 	minIterationsPerCPU = 10000
 )
 
+type Item interface {
+	any
+}
+
+type Slice[T Item] interface {
+	~[]T
+}
+
+type ApplyBitFlipsFunc[E Item] func(combination UniqueUnorderedCombination, data []E)
+
 // CheckFunc is the function used if the sought value is found. Return true
 // if data is the sought value, and return false if it is not.
-type CheckFunc func(ctx interface{}, data []byte) bool
+type CheckFunc[E Item] func(ctx interface{}, data []E) bool
 
 // InitFunc is the function executed for each goroutine before brute-forcing.
 // It returns a data, which will be passed as argument `ctx` to CheckFunc.
 type InitFunc func() (interface{}, error)
 
-type bruteForcer struct {
-	initialData []byte
-	initFunc    InitFunc
-	checkFunc   CheckFunc
+type bruteForcer[E Item, T Slice[E]] struct {
+	initialData       T
+	initFunc          InitFunc
+	checkFunc         CheckFunc[E]
+	applyBitFlipsFunc ApplyBitFlipsFunc[E]
 }
 
-// BruteForceBytes brute forces a value until checkFunc will return true or
+// BruteForce brute forces a value until checkFunc will return true or
 // combinations will be out. It starts with value initialData and then
 // tries combination with the hamming distance (relatively to initialDate) not
 // greater than maxDistance.
 //
 // On success it returns the combination of bits which combination are required
 // to be changed. To apply these changes use method ApplyBitFlips.
-func BruteForceBytes(initialData []byte, maxDistance uint64, initFunc InitFunc, checkFunc CheckFunc, maxConcurrency uint) (UniqueUnorderedCombination, error) {
-	return newBruteForcer(initialData, initFunc, checkFunc).run(maxDistance, maxConcurrency)
+func BruteForce[E Item, T Slice[E]](
+	initialData T,
+	itemSize uint64,
+	maxDistance uint64,
+	initFunc InitFunc,
+	checkFunc CheckFunc[E],
+	applyBitFlipsFunc ApplyBitFlipsFunc[E],
+	maxConcurrency uint,
+) (UniqueUnorderedCombination, error) {
+	return run(
+		newBruteForcer(initialData, initFunc, checkFunc, applyBitFlipsFunc),
+		itemSize,
+		maxDistance,
+		maxConcurrency,
+	)
 }
 
-func newBruteForcer(initialData []byte, initFunc InitFunc, checkFunc CheckFunc) *bruteForcer {
+func newBruteForcer[E Item, T Slice[E]](
+	initialData T,
+	initFunc InitFunc,
+	checkFunc CheckFunc[E],
+	applyBitFlipsFunc ApplyBitFlipsFunc[E],
+) *bruteForcer[E, T] {
 	if initFunc == nil {
 		initFunc = func() (interface{}, error) { return nil, nil }
 	}
-	return &bruteForcer{
-		initialData: initialData,
-		initFunc:    initFunc,
-		checkFunc:   checkFunc,
+	return &bruteForcer[E, T]{
+		initialData:       initialData,
+		initFunc:          initFunc,
+		checkFunc:         checkFunc,
+		applyBitFlipsFunc: applyBitFlipsFunc,
 	}
 }
 
-func (b *bruteForcer) run(maxDistance uint64, maxConcurrency uint) (UniqueUnorderedCombination, error) {
+func run[E Item, T Slice[E]](b *bruteForcer[E, T], itemSize uint64, maxDistance uint64, maxConcurrency uint) (UniqueUnorderedCombination, error) {
 	ctx, err := b.initFunc()
 	if err != nil {
 		return nil, err
@@ -60,7 +90,7 @@ func (b *bruteForcer) run(maxDistance uint64, maxConcurrency uint) (UniqueUnorde
 		return NewUniqueUnorderedCombination(0), nil
 	}
 
-	totalBitLength := uint64(len(b.initialData)) * 8
+	totalBitLength := uint64(len(b.initialData)) * itemSize
 	if maxDistance > totalBitLength {
 		maxDistance = totalBitLength
 	}
@@ -116,7 +146,7 @@ func (b *bruteForcer) run(maxDistance uint64, maxConcurrency uint) (UniqueUnorde
 			wg.Add(1)
 			go func(combinationIDStart, combinationIDEnd uint64, errChan chan<- error) {
 				defer wg.Done()
-				dataCopy := make([]byte, len(b.initialData))
+				dataCopy := make(T, len(b.initialData))
 				copy(dataCopy, b.initialData)
 
 				iterator := NewUniqueUnorderedCombinationIterator(distance, int64(totalBitLength)-1)
@@ -136,7 +166,7 @@ func (b *bruteForcer) run(maxDistance uint64, maxConcurrency uint) (UniqueUnorde
 						return
 					}
 
-					if b.try(bfctx, dataCopy, iterator) {
+					if try(b, bfctx, dataCopy, iterator) {
 						locker.Lock()
 						resultData = iterator.GetCombination()
 						locker.Unlock()
@@ -157,7 +187,7 @@ func (b *bruteForcer) run(maxDistance uint64, maxConcurrency uint) (UniqueUnorde
 
 		var errors errors.MultiError
 		for err := range errChan {
-			_ = errors.Add(err)
+			errors.Add(err)
 		}
 
 		if len(errors) > 0 {
@@ -172,9 +202,9 @@ func (b *bruteForcer) run(maxDistance uint64, maxConcurrency uint) (UniqueUnorde
 	return nil, nil
 }
 
-func (b *bruteForcer) try(ctx interface{}, data []byte, iterator *UniqueUnorderedCombinationIterator) bool {
+func try[E Item, T Slice[E]](b *bruteForcer[E, T], ctx interface{}, data T, iterator *UniqueUnorderedCombinationIterator) bool {
 	// flipping the bits
-	iterator.ApplyBitFlips(data)
+	b.applyBitFlipsFunc(iterator.GetCombinationUnsafe(), data)
 
 	// try
 	if b.checkFunc(ctx, data) {
@@ -182,6 +212,6 @@ func (b *bruteForcer) try(ctx interface{}, data []byte, iterator *UniqueUnordere
 	}
 
 	// wrong, flipping back the bits
-	iterator.ApplyBitFlips(data)
+	b.applyBitFlipsFunc(iterator.GetCombinationUnsafe(), data)
 	return false
 }

--- a/pkg/bruteforcer/brute_forcer_test.go
+++ b/pkg/bruteforcer/brute_forcer_test.go
@@ -15,7 +15,7 @@ func TestBruteForce(t *testing.T) {
 	m := map[uint64]struct{}{}
 	maxDistance := 4
 	b := make([]byte, 4)
-	result, err := BruteForce(b, 8, uint64(maxDistance), nil, func(_ interface{}, data []byte) bool {
+	result, err := BruteForce(b, 8, 0, uint64(maxDistance), nil, func(_ interface{}, data []byte) bool {
 		l.Lock()
 		defer l.Unlock()
 		buf := make([]byte, 8)
@@ -51,15 +51,19 @@ func BenchmarkBruteForce(b *testing.B) {
 			panic(checkFuncName)
 		}
 		b.Run(checkFuncName, func(b *testing.B) {
-			for distance := 1; distance <= 6; distance++ {
-				b.Run(fmt.Sprintf("distance_%d", distance), func(b *testing.B) {
-					for dataSize := 1; dataSize <= 8; dataSize++ {
-						b.Run(fmt.Sprintf("dataSize_%d", dataSize), func(b *testing.B) {
-							data := make([]byte, dataSize)
-							b.ReportAllocs()
-							b.ResetTimer()
-							for i := 0; i < b.N; i++ {
-								_, _ = BruteForce(data, 8, uint64(distance), nil, checkFunc, ApplyBitFlipsBytes, 0)
+			for minDistance := 1; minDistance <= 6; minDistance++ {
+				b.Run(fmt.Sprintf("minDistance_%d", minDistance), func(b *testing.B) {
+					for maxDistance := minDistance; maxDistance <= 6; maxDistance++ {
+						b.Run(fmt.Sprintf("maxDistance_%d", maxDistance), func(b *testing.B) {
+							for dataSize := 1; dataSize <= 8; dataSize++ {
+								b.Run(fmt.Sprintf("dataSize_%d", dataSize), func(b *testing.B) {
+									data := make([]byte, dataSize)
+									b.ReportAllocs()
+									b.ResetTimer()
+									for i := 0; i < b.N; i++ {
+										_, _ = BruteForce(data, 8, uint64(minDistance), uint64(maxDistance), nil, checkFunc, ApplyBitFlipsBytes, 0)
+									}
+								})
 							}
 						})
 					}

--- a/pkg/bruteforcer/brute_forcer_test.go
+++ b/pkg/bruteforcer/brute_forcer_test.go
@@ -15,7 +15,7 @@ func TestBruteForce(t *testing.T) {
 	m := map[uint64]struct{}{}
 	maxDistance := 4
 	b := make([]byte, 4)
-	result, err := BruteForceBytes(b, uint64(maxDistance), nil, func(_ interface{}, data []byte) bool {
+	result, err := BruteForce(b, 8, uint64(maxDistance), nil, func(_ interface{}, data []byte) bool {
 		l.Lock()
 		defer l.Unlock()
 		buf := make([]byte, 8)
@@ -26,7 +26,7 @@ func TestBruteForce(t *testing.T) {
 		}
 		m[key] = struct{}{}
 		return false
-	}, 0)
+	}, ApplyBitFlipsBytes, 0)
 	require.Nil(t, result)
 	require.Nil(t, err)
 
@@ -36,7 +36,7 @@ func TestBruteForce(t *testing.T) {
 
 func BenchmarkBruteForce(b *testing.B) {
 	for _, checkFuncName := range []string{"noop", "sha1.Sum"} {
-		var checkFunc CheckFunc
+		var checkFunc CheckFunc[byte]
 		switch checkFuncName {
 		case "noop":
 			checkFunc = func(_ interface{}, data []byte) bool {
@@ -59,7 +59,7 @@ func BenchmarkBruteForce(b *testing.B) {
 							b.ReportAllocs()
 							b.ResetTimer()
 							for i := 0; i < b.N; i++ {
-								_, _ = BruteForceBytes(data, uint64(distance), nil, checkFunc, 0)
+								_, _ = BruteForce(data, 8, uint64(distance), nil, checkFunc, ApplyBitFlipsBytes, 0)
 							}
 						})
 					}

--- a/pkg/bruteforcer/indexes.go
+++ b/pkg/bruteforcer/indexes.go
@@ -42,15 +42,23 @@ func NewUniqueUnorderedCombination(amountOfIndexes uint64) UniqueUnorderedCombin
 	return s
 }
 
-// ApplyBitFlips changes bit combination located in combination UniqueUnorderedCombination
+// ApplyBitFlipsBools changes bit combination located in combination UniqueUnorderedCombination
+// of a []bool.
+func ApplyBitFlipsBools(s UniqueUnorderedCombination, v []bool) {
+	for _, idx := range s {
+		v[idx] = !v[idx]
+	}
+}
+
+// ApplyBitFlipsBytes changes bit combination located in combination UniqueUnorderedCombination
 // of a []byte.
-func (s UniqueUnorderedCombination) ApplyBitFlips(b []byte) {
+func ApplyBitFlipsBytes(s UniqueUnorderedCombination, v []byte) {
 	for _, idx := range s {
 		// major bits of "idx" are responsible for item index inside `b`
 		byteIdx := idx >> 3 // idx / 8
 		// minor bits of "idx" are responsible for bit-index inside `b[byteIndex]`
 		bitIdx := idx & 0x7 // idx mod 8
-		b[byteIdx] ^= 1 << bitIdx
+		v[byteIdx] ^= 1 << bitIdx
 	}
 }
 
@@ -319,11 +327,6 @@ func (iter *UniqueUnorderedCombinationIterator) GetCombination() UniqueUnordered
 // GetCombinationUnsafe is an unsafe (but fast) getter of the current combination.
 func (iter *UniqueUnorderedCombinationIterator) GetCombinationUnsafe() UniqueUnorderedCombination {
 	return iter.combination
-}
-
-// ApplyBitFlips flips bits of `b`, indexes of which are defined by current combination.
-func (iter *UniqueUnorderedCombinationIterator) ApplyBitFlips(b []byte) {
-	iter.combination.ApplyBitFlips(b)
 }
 
 // Copy returns a deep copy of the iterator.

--- a/pkg/ostools/file_to_bytes.go
+++ b/pkg/ostools/file_to_bytes.go
@@ -2,7 +2,7 @@ package ostools
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/edsrzf/mmap-go"
@@ -28,7 +28,7 @@ func FileToBytes(filePath string) ([]byte, error) {
 	}
 
 	// An error? OK, let's try the usual way to read data:
-	contents, err = ioutil.ReadAll(file)
+	contents, err = io.ReadAll(file)
 	if err != nil {
 		return nil, fmt.Errorf(`unable to access data of the image-file "%v": %w`,
 			filePath, err)

--- a/pkg/pcr/measurement.go
+++ b/pkg/pcr/measurement.go
@@ -156,7 +156,10 @@ func (m Measurement) GetID() MeasurementID {
 }
 
 // IsFake forces to skip this measurement in real PCR value calculation
-func (m Measurement) IsFake() bool {
+func (m *Measurement) IsFake() bool {
+	if m == nil {
+		return true
+	}
 	return m.ID.IsFake()
 }
 

--- a/pkg/pcr/replay.go
+++ b/pkg/pcr/replay.go
@@ -3,7 +3,6 @@ package pcr
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	pcr "github.com/9elements/converged-security-suite/v2/pkg/pcr/types"
 	"github.com/9elements/converged-security-suite/v2/pkg/tpmeventlog"
@@ -12,7 +11,7 @@ import (
 // Replay reproduces a PCR value given events, PCR index and hash algorithm.
 func Replay(eventLog *tpmeventlog.TPMEventLog, pcrIndex pcr.ID, hashAlgo tpmeventlog.TPMAlgorithm, logOut io.Writer) ([]byte, error) {
 	if logOut == nil {
-		logOut = ioutil.Discard
+		logOut = io.Discard
 	}
 	hash, err := hashAlgo.Hash()
 	if err != nil {

--- a/pkg/pcrbruteforcer/reproduce_event_log.go
+++ b/pkg/pcrbruteforcer/reproduce_event_log.go
@@ -185,11 +185,11 @@ func bruteForceACMPolicyStatus(m pcr.Measurement, imageBytes []byte, expectedPCR
 		return bytes.Equal(hashValue, expectedPCR0DATASHA1Digest)
 	}
 
-	combination, err := bruteforcer.BruteForceBytes(acmPolicyStatus, uint64(maxDistance), newContextFunc, verifyACMPolicyStatusFunc, 0)
+	combination, err := bruteforcer.BruteForce(acmPolicyStatus, 8, uint64(maxDistance), newContextFunc, verifyACMPolicyStatusFunc, bruteforcer.ApplyBitFlipsBytes, 0)
 	if combination == nil {
 		return 0, fmt.Errorf("unable to brute force: %w", err)
 	}
 
-	combination.ApplyBitFlips(acmPolicyStatus)
+	bruteforcer.ApplyBitFlipsBytes(combination, acmPolicyStatus)
 	return registers.ParseACMPolicyStatusRegister(binary.LittleEndian.Uint64(acmPolicyStatus)), nil
 }

--- a/pkg/pcrbruteforcer/reproduce_event_log.go
+++ b/pkg/pcrbruteforcer/reproduce_event_log.go
@@ -7,8 +7,11 @@ import (
 	"encoding/binary"
 	"fmt"
 	"hash"
+	"math"
 	"strings"
+	"sync"
 
+	"github.com/9elements/converged-security-suite/v2/pkg/bruteforcer"
 	"github.com/9elements/converged-security-suite/v2/pkg/pcr"
 	"github.com/9elements/converged-security-suite/v2/pkg/registers"
 	"github.com/9elements/converged-security-suite/v2/pkg/tpmeventlog"
@@ -38,8 +41,8 @@ func eventTypesString(types []*tpmeventlog.EventType) string {
 type Issue error
 
 // ReproduceEventLog verifies measurements through TPM EventLog. If successful,
-// the first returned variable is true; in any case all problems
-// are reported through `error`; and if ACM_POLICY_STATUS should be amended,
+// the first returned variable is true; all mismatches are reported
+// via `[]Issue`; and if ACM_POLICY_STATUS should be amended,
 // then the updated value is returned as the second variable.
 //
 // Current algorithm already supports disabling measurements, may be in future
@@ -49,75 +52,52 @@ type Issue error
 func ReproduceEventLog(
 	eventLog *tpmeventlog.TPMEventLog,
 	hashAlgo tpmeventlog.TPMAlgorithm,
-	measurements pcr.Measurements,
+	inMeasurements pcr.Measurements,
 	imageBytes []byte,
 	settings SettingsReproduceEventLog,
 ) (bool, *registers.ACMPolicyStatus, []Issue, error) {
 	var issues []Issue
 
 	if eventLog == nil {
-		return false, nil, nil, fmt.Errorf("TPM EventLog is not provided")
+		return false, nil, issues, fmt.Errorf("TPM EventLog is not provided")
 	}
 
-	events, err := eventLog.FilterEvents(0, hashAlgo)
+	events, measurements, measurementDigests, alignIssues, err := alignEventsAndMeasurements(eventLog, inMeasurements, imageBytes, hashAlgo)
+	issues = append(issues, alignIssues...)
 	if err != nil {
-		return false, nil, nil, fmt.Errorf("unable to filter events: %w", err)
+		return false, nil, issues, fmt.Errorf("unable to align Events and Measurements: %w", err)
 	}
 
-	var filteredMeasurements pcr.Measurements
-	for _, m := range measurements {
-		if m.IsFake() && m.ID != pcr.MeasurementIDInit {
-			continue
-		}
-		if len(m.EventLogEventTypes()) == 0 {
-			issues = append(issues, fmt.Errorf("the flow requires a measurement, which is not expected to be logged into EventLog"))
-			continue
-		}
-		filteredMeasurements = append(filteredMeasurements, m)
+	if len(events) != len(measurements) || len(measurements) != len(measurementDigests) {
+		return false, nil, issues, fmt.Errorf("internal error (should never happen): len(events) != len(measurements) || len(measurements) != len(measurementDigests): %d != %d || %d != %d", len(events), len(measurements), len(measurements), len(measurementDigests))
 	}
 
 	var updatedACMPolicyStatusValue *registers.ACMPolicyStatus
-	evIdx, mIdx := 0, 0
 
-	result := true
-	for evIdx < len(events) && mIdx < len(filteredMeasurements) {
-		m := filteredMeasurements[mIdx]
-		mIdx++
+	isEventLogMatchesMeasurements := true
+	for idx := 0; idx < len(measurements); idx++ {
+		m := measurements[idx]
+		mD := measurementDigests[idx]
+		ev := events[idx]
 
-		ev := eventLog.Events[evIdx]
-
-		matched := false
-
-		for _, eventType := range m.EventLogEventTypes() {
-			if *eventType == ev.Type {
-				matched = true
-			}
-		}
-
-		if !matched {
-			issues = append(issues, fmt.Errorf("missing measurement '%s' in EventLog (expected event types [%s], but received %d (0x%X) on evIdx==%d)", m.ID, eventTypesString(m.EventLogEventTypes()), ev.Type, ev.Type, evIdx))
-			// We assume it happened because some measurements are missing
-			// in the eventlog, therefore we skip the measurements hoping
-			// that next measurement match with the EventLog entry.
+		if m == nil {
+			issues = append(issues, fmt.Errorf("extra entry in EventLog of type %d (0x%X) on evIdx==%d", ev.Type, ev.Type, idx))
+			isEventLogMatchesMeasurements = false
 			continue
 		}
-		evIdx++
+
+		if ev == nil {
+			issues = append(issues, fmt.Errorf("missing entry (for measurement '%s') in EventLog (expected event types are: %s)", m.ID, eventTypesString(m.EventLogEventTypes())))
+			isEventLogMatchesMeasurements = false
+			continue
+		}
 
 		if m.ID == pcr.MeasurementIDInit {
 			// Nothing to compare
 			continue
 		}
 
-		hasherFactory, err := ev.Digest.HashAlgo.Hash()
-		if err != nil {
-			issues = append(issues, fmt.Errorf("invalid hash algo %d in measurement '%s' in EventLog (expected event types %v, but received %d on evIdx==%d)", ev.Digest.HashAlgo, m.ID, m.EventLogEventTypes(), ev.Type, evIdx))
-			continue
-		}
-		hasher := hasherFactory.New()
-		hasher.Write(m.CompileMeasurableData(imageBytes))
-		mHash := hasher.Sum(nil)
-		hasher.Reset()
-		if bytes.Equal(mHash[:], ev.Digest.Digest) {
+		if bytes.Equal(ev.Digest.Digest, mD) {
 			// It matched, everything is OK, let's check next pair.
 			continue
 		}
@@ -132,10 +112,11 @@ func ReproduceEventLog(
 			// If this is the PCR0_DATA measurement then it could be just
 			// a corrupted ACM_POLICY_STATUS register value, let's try
 			// to restore it.
+			//
 			correctedACMPolicyStatus, err := bruteForceACMPolicyStatus(*m, imageBytes, ev.Digest.Digest, settings.SettingsBruteforceACMPolicyStatus)
 			if err != nil {
-				issues = append(issues, fmt.Errorf("PCR0_DATA measurement does not match the digest reported in EventLog and unable to brute force a possible bitflip: %X != %X", mHash[:], ev.Digest.Digest))
-				result = false
+				issues = append(issues, fmt.Errorf("PCR0_DATA measurement does not match the digest reported in EventLog and unable to brute force a possible bitflip: %X != %X", mD, ev.Digest.Digest))
+				isEventLogMatchesMeasurements = false
 				continue
 			}
 			var buf [8]byte
@@ -144,25 +125,12 @@ func ReproduceEventLog(
 			updatedACMPolicyStatusValue = &correctedACMPolicyStatus
 		default:
 			// I do not know how to remediate this problem.
-			issues = append(issues, fmt.Errorf("measurement '%s' does not match the digest reported in EventLog: %X != %X", m.ID, mHash[:], ev.Digest.Digest))
-			result = false
+			issues = append(issues, fmt.Errorf("measurement '%s' does not match the digest reported in EventLog: %X != %X", m.ID, mD, ev.Digest.Digest))
+			isEventLogMatchesMeasurements = false
 		}
 	}
-	if evIdx == 0 {
-		// no-one EventLog entry matched, it could not be considered as "remediated"/"fixed".
-		result = false
-	}
 
-	for ; mIdx < len(filteredMeasurements); mIdx++ {
-		m := filteredMeasurements[mIdx]
-		issues = append(issues, fmt.Errorf("missing measurement '%s' in EventLog", m.ID))
-	}
-	for ; evIdx < len(events); evIdx++ {
-		ev := events[evIdx]
-		issues = append(issues, fmt.Errorf("extra EventLog entry: evIdx == %d: type == %v", evIdx, ev.Type))
-	}
-
-	return result, updatedACMPolicyStatusValue, issues, nil
+	return isEventLogMatchesMeasurements, updatedACMPolicyStatusValue, issues, nil
 }
 
 func bruteForceACMPolicyStatus(
@@ -240,4 +208,343 @@ func bruteForceACMPolicyStatus(
 	}
 
 	return 0, fmt.Errorf("unable to find the value")
+}
+
+func alignEventsAndMeasurements(
+	eventLog *tpmeventlog.TPMEventLog,
+	inMeasurements pcr.Measurements,
+	imageBytes []byte,
+	hashAlgo tpmeventlog.TPMAlgorithm,
+) (
+	events []*tpmeventlog.Event,
+	measurements pcr.Measurements,
+	measurementDigests [][]byte,
+	issues []Issue,
+	err error,
+) {
+	inEvents, err := eventLog.FilterEvents(0, hashAlgo)
+	if err != nil {
+		err = fmt.Errorf("unable to filter TPM EventLog events: %w", err)
+		return
+	}
+
+	var filteredMeasurements pcr.Measurements
+	for _, m := range inMeasurements {
+		if m.IsFake() && m.ID != pcr.MeasurementIDInit {
+			continue
+		}
+		if len(m.EventLogEventTypes()) == 0 {
+			issues = append(issues, fmt.Errorf("the flow requires a measurement, which is not expected to be logged into EventLog"))
+			continue
+		}
+		filteredMeasurements = append(filteredMeasurements, m)
+	}
+	inMeasurements = filteredMeasurements
+
+	hasherFactory, err := hashAlgo.Hash()
+	if err != nil {
+		err = fmt.Errorf("unable to initialize a hash function for algorithm %#v", hashAlgo)
+		return
+	}
+
+	inMeasurementDigests := make([][]byte, 0, len(inMeasurements))
+	for _, m := range inMeasurements {
+		var hash []byte
+		hash, err = m.Calculate(imageBytes, hasherFactory.New())
+		if err != nil {
+			err = fmt.Errorf("unable to cache measurement %#+v: %w", *m, err)
+			return
+		}
+		inMeasurementDigests = append(inMeasurementDigests, hash)
+	}
+
+	disabledEvents, disabledMeasurements, distance, err := bruteForceAlignedEventsAndMeasurements(inEvents, inMeasurements, inMeasurementDigests)
+	if distance == 0 {
+		measurements = inMeasurements
+		measurementDigests = inMeasurementDigests
+		events = inEvents
+		if len(measurements) != len(events) {
+			err = fmt.Errorf("internal error (should not happen): %d != %d; distance miscalculation?", len(measurements), len(events))
+		}
+		return
+	}
+
+	// a defensive check
+	disabledEventsCount := 0
+	for _, v := range disabledEvents {
+		if v {
+			disabledEventsCount++
+		}
+	}
+	disabledMeasurementsCount := 0
+	for _, v := range disabledMeasurements {
+		if v {
+			disabledMeasurementsCount++
+		}
+	}
+	if len(inEvents)-disabledEventsCount != len(inMeasurements)-disabledMeasurementsCount {
+		err = fmt.Errorf("internal error (should never happen): amounts of aligned events and measurements are not equal: %d != %d", len(inEvents)-disabledEventsCount, len(inMeasurements)-disabledMeasurementsCount)
+		return
+	}
+
+	// constructing the aligned slices
+	for evIdx, mIdx, outIdx := 0, 0, 0; evIdx < len(inEvents) || mIdx < len(inMeasurements); outIdx++ {
+		if evIdx < len(inEvents) && disabledEvents[evIdx] {
+			events = append(events, inEvents[evIdx])
+			measurementDigests = append(measurementDigests, nil)
+			measurements = append(measurements, nil)
+			evIdx++
+			continue
+		}
+		if mIdx < len(inMeasurements) && disabledMeasurements[mIdx] {
+			events = append(events, nil)
+			measurementDigests = append(measurementDigests, inMeasurementDigests[mIdx])
+			measurements = append(measurements, inMeasurements[mIdx])
+			mIdx++
+			continue
+		}
+		events = append(events, inEvents[evIdx])
+		measurementDigests = append(measurementDigests, inMeasurementDigests[mIdx])
+		measurements = append(measurements, inMeasurements[mIdx])
+		evIdx++
+		mIdx++
+	}
+
+	return
+}
+
+// bruteForceAlignedEventsAndMeasurements finds an optimal solution of
+// disabled events and measurements to get remaining events and measurements
+// aligned.
+//
+// An optimal follows these rules:
+// * We disable an event or a measurement only if it does not match by both: type and digest.
+// * Prefer digest match over type match.
+func bruteForceAlignedEventsAndMeasurements(
+	events []*tpmeventlog.Event,
+	measurements pcr.Measurements,
+	measurementDigests [][]byte,
+) (disabledEvents []bool, disabledMeasurements []bool, curDistance uint64, err error) {
+	curDistance = uint64(math.MaxUint64)
+	if len(measurements) != len(measurementDigests) {
+		err = fmt.Errorf("internal error: len(measurements) != len(measurementDigests): %d != %d", len(measurements), len(measurementDigests))
+		return
+	}
+
+	disabledItemIdx := make([]bool, len(events)+len(measurements))
+	disabledEvents = disabledItemIdx[:len(events)]
+	disabledMeasurements = disabledItemIdx[len(events):]
+
+	if len(events) == len(measurements) {
+		curDistance = eventAndMeasurementsDistance(events, disabledEvents, measurements, measurementDigests, disabledMeasurements)
+		if curDistance == 0 {
+			return
+		}
+	}
+
+	// Get prepared for bruteforcing.
+	//
+	// How to find the optimal solution?
+	// We just calculate a distance metric and look for its minimum.
+	// The distance metric is calculated in a way to satisfy the rules
+	// listed in the description of "bruteForceAlignedEventsAndMeasurements" above.
+	// See implementation of "eventAndMeasurementsDistance".
+
+	var m sync.Mutex
+	newDisabledMeasurements := make([]bool, len(disabledMeasurements))
+	newDisabledEvents := make([]bool, len(disabledEvents))
+	copy(newDisabledMeasurements, disabledMeasurements)
+	copy(newDisabledEvents, disabledEvents)
+
+	// First of all, align the amounts
+
+	amountDiff := len(events) - len(measurements)
+	switch {
+	case amountDiff == 0:
+		// do nothing
+	case amountDiff < 0:
+		_, _ = bruteforcer.BruteForce(
+			disabledMeasurements,
+			1,
+			uint64(-amountDiff),
+			uint64(-amountDiff),
+			nil,
+			func(ctx any, data []bool) bool {
+				distance := eventAndMeasurementsDistance(events, disabledEvents, measurements, measurementDigests, data)
+				m.Lock()
+				defer m.Unlock()
+				if distance < curDistance {
+					curDistance = distance
+					copy(newDisabledMeasurements, data)
+				}
+				return distance == 0
+			},
+			bruteforcer.ApplyBitFlipsBools,
+			0,
+		)
+		copy(disabledMeasurements, newDisabledMeasurements)
+	case amountDiff > 0:
+		_, _ = bruteforcer.BruteForce(
+			disabledEvents,
+			1,
+			uint64(amountDiff),
+			uint64(amountDiff),
+			nil,
+			func(ctx any, data []bool) bool {
+				distance := eventAndMeasurementsDistance(events, data, measurements, measurementDigests, disabledMeasurements)
+				m.Lock()
+				defer m.Unlock()
+				if distance < curDistance {
+					curDistance = distance
+					copy(newDisabledEvents, data)
+				}
+				return distance == 0
+			},
+			bruteforcer.ApplyBitFlipsBools,
+			0,
+		)
+		copy(disabledEvents, newDisabledEvents)
+	}
+
+	// Now, align the content.
+
+	type _context struct {
+		locker                  sync.Mutex
+		curDistance             uint64
+		newDisabledMeasurements []bool
+	}
+
+	var disabledMeasurementsCount int
+	for _, v := range disabledMeasurements {
+		if v {
+			disabledMeasurementsCount++
+		}
+	}
+	_, _ = bruteforcer.BruteForce(
+		disabledEvents,
+		1,
+		0,
+		5, // arbitrary value based on previous experience, hoping to handle within a second; TODO: add benchmarks
+		func() (any, error) {
+			_newDisabledMeasurements := make([]bool, len(disabledMeasurements))
+			copy(_newDisabledMeasurements, disabledMeasurements)
+			return &_context{
+				curDistance:             math.MaxUint64,
+				newDisabledMeasurements: _newDisabledMeasurements,
+			}, nil
+		},
+		func(_ctx any, _disabledEvents []bool) bool {
+			ctx := _ctx.(*_context)
+			var disabledEventsCount int
+			for _, v := range _disabledEvents {
+				if v {
+					disabledEventsCount++
+				}
+			}
+			boolDistance := (disabledEventsCount - disabledMeasurementsCount) - (len(events) - len(measurements))
+			if boolDistance < 0 {
+				return false
+			}
+			_, _ = bruteforcer.BruteForce(
+				disabledMeasurements,
+				1,
+				uint64(boolDistance),
+				uint64(boolDistance),
+				nil,
+				func(_ any, _disabledMeasurements []bool) bool {
+					var newDisabledMeasurementsCount int
+					for _, v := range _disabledMeasurements {
+						if v {
+							newDisabledMeasurementsCount++
+						}
+					}
+					if newDisabledMeasurementsCount != disabledEventsCount+boolDistance {
+						// sometimes BruteForce will flip from true to false (not only from false to true),
+						// we just skip these cases.
+						return false
+					}
+
+					distance := eventAndMeasurementsDistance(events, _disabledEvents, measurements, measurementDigests, _disabledMeasurements)
+					ctx.locker.Lock()
+					defer ctx.locker.Unlock()
+					if distance < ctx.curDistance {
+						ctx.curDistance = distance
+						copy(ctx.newDisabledMeasurements, _disabledMeasurements)
+					}
+					return distance == 0
+				},
+				bruteforcer.ApplyBitFlipsBools,
+				0,
+			)
+
+			m.Lock()
+			defer m.Unlock()
+			if ctx.curDistance < curDistance {
+				copy(newDisabledEvents, _disabledEvents)
+				copy(newDisabledMeasurements, ctx.newDisabledMeasurements)
+				curDistance = ctx.curDistance
+			}
+			return curDistance == 0
+		},
+		bruteforcer.ApplyBitFlipsBools,
+		0,
+	)
+	copy(disabledEvents, newDisabledEvents)
+	copy(disabledMeasurements, newDisabledMeasurements)
+
+	return
+}
+
+func eventAndMeasurementsDistance(
+	events []*tpmeventlog.Event,
+	evIsSkipped []bool,
+	measurements pcr.Measurements,
+	measurementDigests [][]byte,
+	mIsSkipped []bool,
+) uint64 {
+	distance := uint64(0)
+
+	bigN := uint64(math.MaxUint32) // big enough to be always higher than amount of events and measurements
+
+	for mIdx, evIdx := 0, 0; mIdx < len(measurements) || evIdx < len(events); {
+		if mIdx < len(measurements) && mIsSkipped[mIdx] {
+			distance += bigN
+			mIdx++
+			continue
+		}
+		if evIdx < len(events) && evIsSkipped[evIdx] {
+			distance += bigN
+			evIdx++
+			continue
+		}
+		if mIdx >= len(measurements) || evIdx >= len(events) {
+			panic(fmt.Errorf("should never happen, because the resulting (after skipping) amount of events and measurements should be the same: %d >= %d || %d >= %d", mIdx, len(measurements), evIdx, len(events)))
+		}
+		m := measurements[mIdx]
+		mD := measurementDigests[mIdx]
+		ev := events[evIdx]
+		mIdx++
+		evIdx++
+
+		matchedType := false
+		for _, eventType := range m.EventLogEventTypes() {
+			if *eventType == ev.Type {
+				matchedType = true
+			}
+		}
+
+		if !m.IsFake() && len(ev.Digest.Digest) != len(mD) {
+			panic(fmt.Errorf("should never happen, because the digest types guaranteed to be the same by the alignEventsAndMeasurementsByType implementation: len(ev.Digest.Digest) != len(mD): %d != %d", len(ev.Digest.Digest), len(mD)))
+		}
+		matchedDigest := bytes.Equal(ev.Digest.Digest, mD)
+
+		if !matchedDigest {
+			distance += 2*bigN - 1 // does not overweight a disabled event + disabled measurement
+		}
+		if !matchedType {
+			distance += 2 // together with matchedDigest does overweight a diabled event + disabled measurement
+		}
+	}
+
+	return distance
 }

--- a/pkg/pcrbruteforcer/reproduce_event_log_test.go
+++ b/pkg/pcrbruteforcer/reproduce_event_log_test.go
@@ -22,6 +22,54 @@ func unhex(fataler fataler, h string) []byte {
 	return b
 }
 
+func getTPMEventLog(fataler fataler) *tpmeventlog.TPMEventLog {
+	return &tpmeventlog.TPMEventLog{
+		Events: []*tpmeventlog.Event{
+			{
+				PCRIndex: 0,
+				Type:     tpmeventlog.EV_NO_ACTION,
+				Data:     []byte("StartupLocality\000\003"),
+				Digest: &tpmeventlog.Digest{
+					HashAlgo: 4,
+					Digest:   unhex(fataler, "0000000000000000000000000000000000000000"),
+				},
+			},
+			{
+				PCRIndex: 0,
+				Type:     tpmeventlog.EV_S_CRTM_CONTENTS,
+				Digest: &tpmeventlog.Digest{
+					HashAlgo: 4,
+					Digest:   unhex(fataler, "527C9A38B2F45FBF89C382547E0A0812722A47D3"),
+				},
+			},
+			{
+				PCRIndex: 0,
+				Type:     tpmeventlog.EV_S_CRTM_VERSION,
+				Digest: &tpmeventlog.Digest{
+					HashAlgo: 4,
+					Digest:   unhex(fataler, "C14F556E35C9BB45F189B03F383A6A3E31256681"),
+				},
+			},
+			{
+				PCRIndex: 0,
+				Type:     tpmeventlog.EV_POST_CODE,
+				Digest: &tpmeventlog.Digest{
+					HashAlgo: 4,
+					Digest:   unhex(fataler, "4C9836F73CC42ADBECE7D565B783E618B4A75C22"),
+				},
+			},
+			{
+				PCRIndex: 0,
+				Type:     tpmeventlog.EV_SEPARATOR,
+				Digest: &tpmeventlog.Digest{
+					HashAlgo: 4,
+					Digest:   unhex(fataler, "9069CA78E7450A285173431B3E52C5C25299E473"),
+				},
+			},
+		},
+	}
+}
+
 func TestReproduceEventLog(t *testing.T) {
 	firmwareImage := firmware.FakeIntelFirmware
 
@@ -38,54 +86,32 @@ func TestReproduceEventLog(t *testing.T) {
 	measurements, _, debugInfo, err := pcr.GetMeasurements(firmware, 0, measureOptions...)
 	require.NoError(t, err, fmt.Sprintf("debugInfo: '%v'", debugInfo))
 
-	eventLog := &tpmeventlog.TPMEventLog{
-		Events: []*tpmeventlog.Event{
-			{
-				PCRIndex: 0,
-				Type:     tpmeventlog.EV_NO_ACTION,
-				Data:     []byte("StartupLocality\000\003"),
-				Digest: &tpmeventlog.Digest{
-					HashAlgo: 4,
-					Digest:   unhex(t, "0000000000000000000000000000000000000000"),
-				},
-			},
-			{
-				PCRIndex: 0,
-				Type:     tpmeventlog.EV_S_CRTM_CONTENTS,
-				Digest: &tpmeventlog.Digest{
-					HashAlgo: 4,
-					Digest:   unhex(t, "527C9A38B2F45FBF89C382547E0A0812722A47D3"),
-				},
-			},
-			{
-				PCRIndex: 0,
-				Type:     tpmeventlog.EV_S_CRTM_VERSION,
-				Digest: &tpmeventlog.Digest{
-					HashAlgo: 4,
-					Digest:   unhex(t, "C14F556E35C9BB45F189B03F383A6A3E31256681"),
-				},
-			},
-			{
-				PCRIndex: 0,
-				Type:     tpmeventlog.EV_POST_CODE,
-				Digest: &tpmeventlog.Digest{
-					HashAlgo: 4,
-					Digest:   unhex(t, "4C9836F73CC42ADBECE7D565B783E618B4A75C22"),
-				},
-			},
-			{
-				PCRIndex: 0,
-				Type:     tpmeventlog.EV_SEPARATOR,
-				Digest: &tpmeventlog.Digest{
-					HashAlgo: 4,
-					Digest:   unhex(t, "9069CA78E7450A285173431B3E52C5C25299E473"),
-				},
-			},
-		},
-	}
+	eventLog := getTPMEventLog(t)
 
-	succeeded, acmPolicyStatus, _ := ReproduceEventLog(eventLog, measurements, firmwareImage)
+	succeeded, acmPolicyStatus, _ := ReproduceEventLog(eventLog, tpmeventlog.TPMAlgorithmSHA1, measurements, firmwareImage, DefaultSettingsReproduceEventLog())
 	require.True(t, succeeded)
-	require.NotNil(t, acmPolicyStatus)
 	require.Equal(t, uint64(0x0000000200108681), acmPolicyStatus.Raw())
+}
+
+func BenchmarkReproduceEventLog(b *testing.B) {
+	firmware := getFirmware(b)
+
+	measureOptions := []pcr.MeasureOption{
+		pcr.SetFlow(pcr.FlowIntelCBnT0T),
+		pcr.SetIBBHashDigest(tpm2.AlgSHA1),
+		pcr.SetRegisters(registers.Registers{
+			registers.ParseACMPolicyStatusRegister(0x000000020010868A),
+		}),
+	}
+	measurements, _, debugInfo, err := pcr.GetMeasurements(firmware, 0, measureOptions...)
+	require.NoError(b, err, fmt.Sprintf("debugInfo: '%v'", debugInfo))
+
+	eventLog := getTPMEventLog(b)
+
+	for i := 0; i < b.N; i++ {
+		_, _, err := ReproduceEventLog(eventLog, tpmeventlog.TPMAlgorithmSHA1, measurements, firmware.Buf(), DefaultSettingsReproduceEventLog())
+		if err != nil {
+			panic(err)
+		}
+	}
 }

--- a/pkg/pcrbruteforcer/reproduce_event_log_test.go
+++ b/pkg/pcrbruteforcer/reproduce_event_log_test.go
@@ -88,7 +88,7 @@ func TestReproduceEventLog(t *testing.T) {
 
 	eventLog := getTPMEventLog(t)
 
-	succeeded, acmPolicyStatus, _ := ReproduceEventLog(eventLog, tpmeventlog.TPMAlgorithmSHA1, measurements, firmwareImage, DefaultSettingsReproduceEventLog())
+	succeeded, acmPolicyStatus, _, _ := ReproduceEventLog(eventLog, tpmeventlog.TPMAlgorithmSHA1, measurements, firmwareImage, DefaultSettingsReproduceEventLog())
 	require.True(t, succeeded)
 	require.Equal(t, uint64(0x0000000200108681), acmPolicyStatus.Raw())
 }
@@ -109,7 +109,7 @@ func BenchmarkReproduceEventLog(b *testing.B) {
 	eventLog := getTPMEventLog(b)
 
 	for i := 0; i < b.N; i++ {
-		_, _, err := ReproduceEventLog(eventLog, tpmeventlog.TPMAlgorithmSHA1, measurements, firmware.Buf(), DefaultSettingsReproduceEventLog())
+		_, _, _, err := ReproduceEventLog(eventLog, tpmeventlog.TPMAlgorithmSHA1, measurements, firmware.Buf(), DefaultSettingsReproduceEventLog())
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/pcrbruteforcer/reproduce_expected_pcr0.go
+++ b/pkg/pcrbruteforcer/reproduce_expected_pcr0.go
@@ -712,7 +712,7 @@ func (cs *combinatorialSearch) Process(
 		return matched
 	}
 
-	combination, err := bruteforcer.BruteForce(startACMPolicyStatus, 8, uint64(cs.limit), initFunc, verifyFunc, bruteforcer.ApplyBitFlipsBytes, 0)
+	combination, err := bruteforcer.BruteForce(startACMPolicyStatus, 8, 0, uint64(cs.limit), initFunc, verifyFunc, bruteforcer.ApplyBitFlipsBytes, 0)
 	if combination == nil || err != nil {
 		return nil, err
 	}

--- a/pkg/pcrbruteforcer/reproduce_expected_pcr0.go
+++ b/pkg/pcrbruteforcer/reproduce_expected_pcr0.go
@@ -686,7 +686,7 @@ func (cs *combinatorialSearch) Process(locality uint8, ms []*pcr.CachedMeasureme
 	}
 	start := ms[0].Data[0].ForceData
 
-	combination, err := bruteforcer.BruteForceBytes(start, uint64(cs.limit), initFunc, verifyFunc, 0)
+	combination, err := bruteforcer.BruteForce(start, 8, uint64(cs.limit), initFunc, verifyFunc, bruteforcer.ApplyBitFlipsBytes, 0)
 	if combination == nil || err != nil {
 		return nil, nil, err
 	}
@@ -696,7 +696,7 @@ func (cs *combinatorialSearch) Process(locality uint8, ms []*pcr.CachedMeasureme
 
 	var issue error
 	if len(combination) != 0 {
-		combination.ApplyBitFlips(ACMRegValue)
+		bruteforcer.ApplyBitFlipsBytes(combination, ACMRegValue)
 		issue = fmt.Errorf("changed ACM_POLICY_STATUS from %X to %X", start, ACMRegValue)
 	}
 

--- a/pkg/provisioning/cbnt/config.go
+++ b/pkg/provisioning/cbnt/config.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/9elements/converged-security-suite/v2/pkg/tools"
@@ -46,7 +45,7 @@ type Options struct {
 // ParseConfig parses a boot guard option json file
 func ParseConfig(filepath string) (*Options, error) {
 	var cbnto Options
-	data, err := ioutil.ReadFile(filepath)
+	data, err := os.ReadFile(filepath)
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +176,7 @@ func SetKM(cbnto *Options) (*key.Manifest, error) {
 // GenerateBPM generates a Boot Policy Manifest with the given config and firmware image
 func GenerateBPM(cbnto *Options, biosFilepath string) (*bootpolicy.Manifest, error) {
 	bpm := bootpolicy.NewManifest()
-	data, err := ioutil.ReadFile(biosFilepath)
+	data, err := os.ReadFile(biosFilepath)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read file '%s': %w", biosFilepath, err)
 	}
@@ -231,7 +230,7 @@ func ReadConfigFromBIOSImage(biosFilepath string, configFilepath *os.File) (*Opt
 	var cbnto Options
 	var bpm *bootpolicy.Manifest
 	var km *key.Manifest
-	bios, err := ioutil.ReadFile(biosFilepath)
+	bios, err := os.ReadFile(biosFilepath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provisioning/cbnt/keygen.go
+++ b/pkg/provisioning/cbnt/keygen.go
@@ -11,7 +11,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -205,7 +204,7 @@ func DecryptPrivKey(data []byte, password string) (crypto.PrivateKey, error) {
 
 // ReadPubKey ready a pem encoded RSA/ECC public key file
 func ReadPubKey(path string) (crypto.PublicKey, error) {
-	raw, err := ioutil.ReadFile(path)
+	raw, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provisioning/cbnt/tools.go
+++ b/pkg/provisioning/cbnt/tools.go
@@ -3,7 +3,6 @@ package cbnt
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/9elements/converged-security-suite/v2/pkg/tools"
@@ -164,7 +163,7 @@ func CalculateNEMSize(image []byte, bpm *bootpolicy.Manifest, km *key.Manifest, 
 // StitchFITEntries takes a firmware filename, an acm, a boot policy manifest and a key manifest as byte slices
 // and writes the information into the Firmware Interface Table of the firmware image.
 func StitchFITEntries(biosFilename string, acm, bpm, km []byte) error {
-	image, err := ioutil.ReadFile(biosFilename)
+	image, err := os.ReadFile(biosFilename)
 	if err != nil {
 		return err
 	}
@@ -293,7 +292,7 @@ func FindAdditionalIBBs(imagepath string) ([]bootpolicy.IBBSegment, error) {
 	if err != nil {
 		// To be sure the image file is closed before reading from it again
 		image.Close()
-		img, err := ioutil.ReadFile(imagepath)
+		img, err := os.ReadFile(imagepath)
 		if err != nil {
 			return ibbs, err
 		}

--- a/pkg/tools/acm_test.go
+++ b/pkg/tools/acm_test.go
@@ -1,13 +1,12 @@
 package tools
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
 
 func TestParseandValidateACMHeader(t *testing.T) {
-	file, err := ioutil.ReadFile("./tests/sinit_acm.bin")
+	file, err := os.ReadFile("./tests/sinit_acm.bin")
 	if err != nil {
 		t.Errorf("Failed to read file: %v", err)
 	}
@@ -29,7 +28,7 @@ func TestParseandValidateACMHeader(t *testing.T) {
 }
 
 func TestACMParser(t *testing.T) {
-	file, err := ioutil.ReadFile("./tests/sinit_acm.bin")
+	file, err := os.ReadFile("./tests/sinit_acm.bin")
 	if err != nil {
 		t.Errorf("Failed to read file: %v", err)
 	}
@@ -49,7 +48,7 @@ func TestACMParser(t *testing.T) {
 }
 
 func TestACMSize(t *testing.T) {
-	file, err := ioutil.ReadFile("./tests/sinit_acm.bin")
+	file, err := os.ReadFile("./tests/sinit_acm.bin")
 	if err != nil {
 		t.Errorf("Failed to read file: %v", err)
 	}
@@ -69,7 +68,7 @@ func TestACMSize(t *testing.T) {
 }
 
 func TestACMParser2(t *testing.T) {
-	file, err := ioutil.ReadFile("./tests/bios_acm.bin")
+	file, err := os.ReadFile("./tests/bios_acm.bin")
 	if err != nil {
 		t.Errorf("ACMParser() failed: %v", err)
 	}
@@ -89,7 +88,7 @@ func TestACMParser2(t *testing.T) {
 }
 
 func TestACMSize2(t *testing.T) {
-	file, err := ioutil.ReadFile("./tests/bios_acm.bin")
+	file, err := os.ReadFile("./tests/bios_acm.bin")
 	if err != nil {
 		t.Errorf("ACMSize() failed: %v", err)
 	}

--- a/pkg/tools/config.go
+++ b/pkg/tools/config.go
@@ -3,7 +3,7 @@ package tools
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/9elements/go-linux-lowlevel-hw/pkg/hwapi"
 	"github.com/google/go-tpm/tpm2"
@@ -27,7 +27,7 @@ type jsonConfig struct {
 func ParseConfig(filepath string) (*Configuration, error) {
 	var jConfig jsonConfig
 	var config Configuration
-	data, err := ioutil.ReadFile(filepath)
+	data, err := os.ReadFile(filepath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tools/lcp_test.go
+++ b/pkg/tools/lcp_test.go
@@ -2,12 +2,12 @@ package tools
 
 import (
 	"crypto"
-	"io/ioutil"
+	"os"
 	"testing"
 )
 
 func TestLCPParser(t *testing.T) {
-	file, err := ioutil.ReadFile("./tests/pol.bin")
+	file, err := os.ReadFile("./tests/pol.bin")
 	if err != nil {
 		t.Errorf("LCPParser() read failed: %v", err)
 	}
@@ -19,7 +19,7 @@ func TestLCPParser(t *testing.T) {
 }
 
 func TestLCPParser2(t *testing.T) {
-	file, err := ioutil.ReadFile("./tests/pol2.bin")
+	file, err := os.ReadFile("./tests/pol2.bin")
 	if err != nil {
 		t.Errorf("LCPParser() read failed: %v", err)
 	}
@@ -32,7 +32,7 @@ func TestLCPParser2(t *testing.T) {
 
 func TestLCPParser3(t *testing.T) {
 	var lcp2 *LCPPolicy2
-	file, err := ioutil.ReadFile("./tests/pol3.bin")
+	file, err := os.ReadFile("./tests/pol3.bin")
 	if err != nil {
 		t.Errorf("LCPDataParser() failed: %v", err)
 	}
@@ -45,7 +45,7 @@ func TestLCPParser3(t *testing.T) {
 }
 
 func TestLCPDataParser(t *testing.T) {
-	file, err := ioutil.ReadFile("./tests/poldata.bin")
+	file, err := os.ReadFile("./tests/poldata.bin")
 	if err != nil {
 		t.Errorf("LCPDataParser() failed: %v", err)
 	}
@@ -59,7 +59,7 @@ func TestLCPDataParser(t *testing.T) {
 }
 
 func TestLCPDataParser2(t *testing.T) {
-	file, err := ioutil.ReadFile("./tests/poldata2.bin")
+	file, err := os.ReadFile("./tests/poldata2.bin")
 	if err != nil {
 		t.Errorf("LCPDataParser() failed: %v", err)
 	}

--- a/pkg/tpm/read_pcr_from_tpm.go
+++ b/pkg/tpm/read_pcr_from_tpm.go
@@ -2,7 +2,7 @@ package tpm
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/9elements/converged-security-suite/v2/pkg/errors"
 	pcrtypes "github.com/9elements/converged-security-suite/v2/pkg/pcr/types"
@@ -21,7 +21,7 @@ func ReadPCRFromTPM(pcrIndex pcrtypes.ID, alg tpm2.Algorithm) ([]byte, error) {
 	var mErr errors.MultiError
 
 	// Try to read PCR values from sysfs
-	if pcrsData, err := ioutil.ReadFile(tpm12PCRsPath); err == nil {
+	if pcrsData, err := os.ReadFile(tpm12PCRsPath); err == nil {
 		if pcrs, err := parseSysfsPCRs(pcrsData); err == nil {
 			return pcrs[pcrIndex], nil
 		}

--- a/pkg/tpmdetection/detection.go
+++ b/pkg/tpmdetection/detection.go
@@ -3,7 +3,6 @@ package tpmdetection
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strings"
@@ -78,7 +77,7 @@ func local(devicePath, capabilities string) (Type, error) {
 		return 0, fmt.Errorf("failed to check existance of %s, err: %w", devicePath, err)
 	}
 
-	caps, err := ioutil.ReadFile(capabilities)
+	caps, err := os.ReadFile(capabilities)
 	if err != nil {
 		// This file may not exist for TPM2.0
 		if os.IsNotExist(err) {

--- a/pkg/tpmdetection/detection_test.go
+++ b/pkg/tpmdetection/detection_test.go
@@ -2,7 +2,6 @@ package tpmdetection
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -10,7 +9,7 @@ import (
 
 func TestTPMDetection(t *testing.T) {
 	t.Run("no_tpm_device", func(t *testing.T) {
-		d, err := ioutil.TempDir("", "tpm_detection")
+		d, err := os.MkdirTemp("", "tpm_detection")
 		if err != nil {
 			t.Errorf("failed to create temp director: %vy", err)
 			t.Skip()
@@ -28,7 +27,7 @@ func TestTPMDetection(t *testing.T) {
 		}
 	})
 
-	d, err := ioutil.TempDir("", "tpm_detection")
+	d, err := os.MkdirTemp("", "tpm_detection")
 	if err != nil {
 		t.Errorf("failed to create temp director: %vy", err)
 		t.Skip()

--- a/pkg/tpmeventlog/tpm_event_log.go
+++ b/pkg/tpmeventlog/tpm_event_log.go
@@ -2,7 +2,6 @@ package tpmeventlog
 
 import (
 	"io"
-	"io/ioutil"
 
 	"github.com/google/go-attestation/attest"
 	"github.com/google/go-tpm/tpm2"
@@ -44,7 +43,7 @@ const (
 
 // Parse parses a binary EventLog.
 func Parse(input io.Reader) (*TPMEventLog, error) {
-	b, err := ioutil.ReadAll(input)
+	b, err := io.ReadAll(input)
 	if err != nil {
 		return nil, ErrRead{Err: err}
 	}

--- a/testdata/firmware/go.mod
+++ b/testdata/firmware/go.mod
@@ -1,7 +1,0 @@
-module github.com/9elements/converged-security-suite/v2/testdata/firmware
-
-go 1.17
-
-require github.com/ulikunitz/xz v0.5.10
-
-replace github.com/9elements/converged-security-suite/v2/ => ../../

--- a/testdata/firmware/go.sum
+++ b/testdata/firmware/go.sum
@@ -1,2 +1,0 @@
-github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
-github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=


### PR DESCRIPTION
Please review this PR on per-commit basis.

Here I do multiple improvements into TPM EventLog reproducing code. Sometimes we see TPM EventLog which is not aligned with expected PCR0 measurements. And we want to explain precisely what is wrong with the EventLog. In this PR I'm doing this thing.