### PR TITLE
fix(display_fwinfo): Decompress DXE if required

### DIFF
--- a/cmd/pcr0tool/commands/displayfwinfo/command.go
+++ b/cmd/pcr0tool/commands/displayfwinfo/command.go
@@ -42,7 +42,7 @@ func (cmd *Command) SetupFlagSet(flag *flag.FlagSet) {
 // `args` are the arguments left unused by verb itself and options.
 func (cmd Command) Execute(args []string) {
 	if len(args) < 1 {
-		_, _ = fmt.Fprintf(flag.CommandLine.Output(), "error: no path to the firmare was specified\n")
+		_, _ = fmt.Fprintf(flag.CommandLine.Output(), "error: no path to the firmware was specified\n")
 		usageAndExit()
 	}
 	if len(args) > 1 {


### PR DESCRIPTION
Nowadays DXE is usually compressed, fixing `display_fwinfo` to support this case.

# Before
```
[xaionaro@void converged-security-suite]$ go run ./cmd/pcr0tool/ display_fwinfo ~/pcr0tool-cases/case0/firmware.fd
unable to parse the image info: 'unable to find SMBIOS static data in the firmware: no appropriate nodes found'[xaionaro@void converged-security-suite]$
```
# After
```
[xaionaro@void converged-security-suite]$ go run ./cmd/pcr0tool/ display_fwinfo ~/pcr0tool-cases/case0/firmware.fd
{"Vendor":"American Megatrends International, LLC.","Version":"Y35CLD11","ReleaseDate":"12/12/2012","Revision":"5.29"}
[xaionaro@void converged-security-suite]$
```