### PR TITLE
[pcr] Fix panic in pcr.ValidateManifests.Validate

### DIFF
--- a/pkg/pcr/get_measurements_pcr0_cbnt0t.go
+++ b/pkg/pcr/get_measurements_pcr0_cbnt0t.go
@@ -161,7 +161,11 @@ func getBootPolicyManifest(fitEntries []fit.Entry) (*cbntbootpolicy.Manifest, *f
 		switch fitEntry := fitEntry.(type) {
 		case *fit.EntryBootPolicyManifestRecord:
 			_, bpManifest2, err := fitEntry.ParseData()
-			if err != nil && bpManifest2 != nil {
+			if bpManifest2 == nil {
+				// TODO: add support for non-CBnT BtG
+				return nil, nil, fmt.Errorf("found a non-CBnT BootGuard manifest instead of the CBnT one")
+			}
+			if err != nil {
 				return nil, nil, err
 			}
 			return bpManifest2, fitEntry, nil


### PR DESCRIPTION
Otherwise a panic occurs in `github.com/9elements/converged-security-suite/v2/pkg/pcr/validate_manifests.go:29`.