### PR TITLE
Add tool amd-suite

### DIFF
--- a/cmd/amd-suite/cmd.go
+++ b/cmd/amd-suite/cmd.go
@@ -15,6 +15,10 @@ type context struct {
 	debug bool
 }
 
+type outputFirmwareCmd struct {
+	FwPath string `required name:"fwpath" help:"Path to UEFI firmware image." type:"path"`
+}
+
 type showKeysCmd struct {
 	FwPath   string `required name:"fwpath" help:"Path to UEFI firmware image." type:"path"`
 	PSPLevel uint   `required name:"psp-level" help:"PSP Directory Level to use"`
@@ -53,6 +57,7 @@ var cli struct {
 	ValidateRTM        validateRTMCmd        `cmd help: Validated the signature of the extended RTM volume, which includes RTM and BIOS Directory Table`
 	DumpPSPEntry       dumpPSPEntryCmd       `cmd help:"Dump an entry to a file on the filesystem"`
 	PatchPSPEntry      patchPSPEntryCmd      `cmd help:"take a path on the filesystem pointing to a dump of a PSP entry and re-apply it to the firmware"`
+	OutputFirmware     outputFirmwareCmd     `cmd help:"Outputs information about the firmware and PSP/BIOS structure"`
 }
 
 func parseAmdFw(path string) (*amd_manifest.AMDFirmware, error) {
@@ -66,6 +71,25 @@ func parseAmdFw(path string) (*amd_manifest.AMDFirmware, error) {
 	}
 
 	return amdFw, nil
+}
+
+func (s *outputFirmwareCmd) Run(ctx *context) error {
+	amdFw, err := parseAmdFw(s.FwPath)
+	if err != nil {
+		return fmt.Errorf("could not parse firmware image: %w", err)
+	}
+
+	err = psb.OutputPSPEntries(amdFw)
+	if err != nil {
+		return fmt.Errorf("could not output PSP firmware info: %w", err)
+	}
+
+	err = psb.OutputBIOSEntries(amdFw)
+	if err != nil {
+		return fmt.Errorf("could not output BIOS firmware info: %w", err)
+	}
+
+	return nil
 }
 
 func (s *showKeysCmd) Run(ctx *context) error {

--- a/cmd/amd-suite/cmd.go
+++ b/cmd/amd-suite/cmd.go
@@ -28,10 +28,9 @@ func (s *showKeyDBCmd) Run(ctx *context) error {
 		return fmt.Errorf("could not parse firmware image: %w", err)
 	}
 
-	keyDB, err := psb.GetKeyDB(firmware)
+	_, err = psb.GetKeyDB(firmware)
 	if err != nil {
-		return fmt.Errorf("could not show key database: %w", err)
+		return fmt.Errorf("could not extract key database: %w", err)
 	}
-	fmt.Println(keyDB.String())
 	return nil
 }

--- a/cmd/amd-suite/cmd.go
+++ b/cmd/amd-suite/cmd.go
@@ -14,27 +14,32 @@ type context struct {
 }
 
 type showKeysCmd struct {
-	FwPath string `arg required name:"fwpath" help:"Path to UEFI firmware image." type:"path"`
+	FwPath   string `arg required name:"fwpath" help:"Path to UEFI firmware image." type:"path"`
+	PSPLevel uint   `arg required name:"psp-level" help:"PSP Directory Level to use"`
 }
 
 type validatePSPEntriesCmd struct {
 	FwPath     string   `arg required name:"fwpath" help:"Path to UEFI firmware image." type:"path"`
+	PSPLevel   uint     `arg required name:"psp-level" help:"PSP Directory Level to use"`
 	PSPEntries []string `arg required name:"validate-psp-entries" help:"Validates the signature of PSP entries given as argument." type:"list"`
 }
 
 type validateRTMCmd struct {
-	FwPath string `arg required name:"fwpath" help:"Path to UEFI firmware image." type:"path"`
+	FwPath    string `arg required name:"fwpath" help:"Path to UEFI firmware image." type:"path"`
+	BIOSLevel uint   `arg required name:"bios-level" help:"BIOS Directory Level to use"`
 }
 
 type dumpPSPEntryCmd struct {
 	FwPath    string `arg required name:"fwpath" help:"Path to UEFI firmware image." type:"path"`
 	PSPEntry  string `arg required name:"dump_psp-entry" help:"dump PSP entry to system file." type:"string"`
+	PSPLevel  uint   `arg required name:"psp-level" help:"PSP Directory Level to use"`
 	EntryFile string `arg required name:"entry_path" help:"Path to entry file." type:"path"`
 }
 
 type patchPSPEntryCmd struct {
 	FwPath               string `arg required name:"fwpath" help:"Path to UEFI firmware image." type:"path"`
 	PSPEntry             string `arg required name:"patch-psp-entry" help:"dump PSP entry to system file." type:"string"`
+	PSPLevel             uint   `arg required name:"psp-level" help:"PSP Directory Level to use"`
 	EntryFile            string `arg required name:"modified_entry_path" help:"Path to modified entry file." type:"path"`
 	ModifiedFirmwareFile string `arg required name:"modified_fwpath" help:"Path to UEFI firmware modified image." type:"path"`
 }
@@ -54,7 +59,7 @@ func (s *showKeysCmd) Run(ctx *context) error {
 		return fmt.Errorf("could not parse firmware image: %w", err)
 	}
 
-	keySet, err := psb.GetKeys(firmware)
+	keySet, err := psb.GetKeys(firmware, s.PSPLevel)
 	if err != nil {
 		return fmt.Errorf("could not extract keys from the firmware image: %w", err)
 	}
@@ -69,7 +74,7 @@ func (v *validatePSPEntriesCmd) Run(ctx *context) error {
 		return fmt.Errorf("could not parse firmware image: %w", err)
 	}
 
-	signatureValidations, err := psb.ValidatePSPEntries(firmware, v.PSPEntries)
+	signatureValidations, err := psb.ValidatePSPEntries(firmware, v.PSPLevel, v.PSPEntries)
 	if err != nil {
 		return err
 	}
@@ -88,7 +93,7 @@ func (v *validateRTMCmd) Run(ctx *context) error {
 		return fmt.Errorf("could not parse firmware image: %w", err)
 	}
 
-	signatureValidation, err := psb.ValidateRTM(firmware)
+	signatureValidation, err := psb.ValidateRTM(firmware, v.BIOSLevel)
 	if err != nil {
 		return err
 	}
@@ -102,7 +107,7 @@ func (v *dumpPSPEntryCmd) Run(ctx *context) error {
 		return fmt.Errorf("could not parse firmware image: %w", err)
 	}
 
-	n, err := psb.DumpPSPEntry(firmware, v.PSPEntry, v.EntryFile)
+	n, err := psb.DumpPSPEntry(firmware, v.PSPLevel, v.PSPEntry, v.EntryFile)
 	if err != nil {
 		return err
 	}
@@ -116,7 +121,7 @@ func (v *patchPSPEntryCmd) Run(ctx *context) error {
 		return fmt.Errorf("could not parse firmware image: %w", err)
 	}
 
-	n, err := psb.PatchPSPEntry(firmware, v.PSPEntry, v.EntryFile, v.ModifiedFirmwareFile)
+	n, err := psb.PatchPSPEntry(firmware, v.PSPLevel, v.PSPEntry, v.EntryFile, v.ModifiedFirmwareFile)
 	if err != nil {
 		return err
 	}

--- a/cmd/amd-suite/cmd.go
+++ b/cmd/amd-suite/cmd.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/9elements/converged-security-suite/v2/pkg/uefi"
 
-	amd_manifest "github.com/9elements/converged-security-suite/v2/pkg/amd/manifest"
+	amd_manifest "github.com/linuxboot/fiano/pkg/amd/manifest"
 )
 
 // Context for kong command line parser

--- a/cmd/amd-suite/cmd.go
+++ b/cmd/amd-suite/cmd.go
@@ -13,7 +13,7 @@ type context struct {
 	debug bool
 }
 
-type showKeyDBCmd struct {
+type showKeysCmd struct {
 	FwPath string `arg required name:"fwpath" help:"Path to UEFI firmware image." type:"path"`
 }
 
@@ -24,22 +24,22 @@ type validatePSPEntriesCmd struct {
 
 var cli struct {
 	Debug              bool                  `help:"Enable debug mode"`
-	ShowKeyDB          showKeyDBCmd          `cmd help:"Shows content of Key Database"`
+	ShowKeys           showKeysCmd           `cmd help:"Shows all key known to the system, together with their origin"`
 	ValidatePSPEntries validatePSPEntriesCmd `cmd help:"Validates signatures of PSP entries"`
 }
 
-func (s *showKeyDBCmd) Run(ctx *context) error {
+func (s *showKeysCmd) Run(ctx *context) error {
 	firmware, err := uefi.ParseUEFIFirmwareFile(s.FwPath)
 	if err != nil {
 		return fmt.Errorf("could not parse firmware image: %w", err)
 	}
 
-	keyDB, err := psb.GetKeyDB(firmware)
+	keySet, err := psb.GetKeys(firmware)
 	if err != nil {
-		return fmt.Errorf("could not extract key database: %w", err)
+		return fmt.Errorf("could not extract keys from the firmware image: %w", err)
 	}
 
-	fmt.Println(keyDB.String())
+	fmt.Println(keySet.String())
 	return nil
 }
 

--- a/cmd/amd-suite/cmd.go
+++ b/cmd/amd-suite/cmd.go
@@ -205,7 +205,7 @@ func (v *dumpPSPEntryCmd) Run(ctx *context) error {
 
 func (v *dumpBIOSEntryCmd) Run(ctx *context) error {
 	return dumpHelper(v.FwPath, v.Entry, v.EntryFile, func(amdFw *amd_manifest.AMDFirmware, entryID uint32, w io.Writer) (int, error) {
-		return psb.DumpBIOSEntry(amdFw, v.BIOSLevel, amd_manifest.BIOSDirectoryTableEntryType(entryID), int(v.Instance), w)
+		return psb.DumpBIOSEntry(amdFw, v.BIOSLevel, amd_manifest.BIOSDirectoryTableEntryType(entryID), v.Instance, w)
 	})
 }
 
@@ -260,6 +260,6 @@ func (v *patchPSPEntryCmd) Run(ctx *context) error {
 
 func (v *patchBIOSEntryCmd) Run(ctx *context) error {
 	return patchHelper(v.FwPath, v.Entry, v.EntryFile, v.ModifiedFirmwareFile, func(amdFw *amd_manifest.AMDFirmware, entryID uint32, r io.Reader, w io.Writer) (int, error) {
-		return psb.PatchBIOSEntry(amdFw, v.BIOSLevel, amd_manifest.BIOSDirectoryTableEntryType(entryID), int(v.Instance), r, w)
+		return psb.PatchBIOSEntry(amdFw, v.BIOSLevel, amd_manifest.BIOSDirectoryTableEntryType(entryID), v.Instance, r, w)
 	})
 }

--- a/cmd/amd-suite/cmd.go
+++ b/cmd/amd-suite/cmd.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"github.com/9elements/converged-security-suite/v2/pkg/amd/psb"
+)
+
+// Context for kong command line parser
+type context struct {
+	debug bool
+}
+
+type showKeyDBCmd struct {
+	FwPath string `arg required name:"fwpath" help:"Path to UEFI firmware image." type:"path"`
+}
+
+var cli struct {
+	Debug     bool         `help:"Enable debug mode"`
+	ShowKeyDB showKeyDBCmd `cmd help:"Shows content of Key Database"`
+}
+
+func (s *showKeyDBCmd) Run(ctx *context) error {
+	psb.ShowKeyDB()
+	return nil
+}

--- a/cmd/amd-suite/cmd.go
+++ b/cmd/amd-suite/cmd.go
@@ -28,5 +28,10 @@ func (s *showKeyDBCmd) Run(ctx *context) error {
 		return fmt.Errorf("could not parse firmware image: %w", err)
 	}
 
-	return psb.GetKeyDB(firmware)
+	keyDB, err := psb.GetKeyDB(firmware)
+	if err != nil {
+		return fmt.Errorf("could not show key database: %w", err)
+	}
+	fmt.Println(keyDB.String())
+	return nil
 }

--- a/cmd/amd-suite/cmd.go
+++ b/cmd/amd-suite/cmd.go
@@ -28,9 +28,11 @@ func (s *showKeyDBCmd) Run(ctx *context) error {
 		return fmt.Errorf("could not parse firmware image: %w", err)
 	}
 
-	_, err = psb.GetKeyDB(firmware)
+	keyDB, err := psb.GetKeyDB(firmware)
 	if err != nil {
 		return fmt.Errorf("could not extract key database: %w", err)
 	}
+
+	fmt.Println(keyDB.String())
 	return nil
 }

--- a/cmd/amd-suite/cmd.go
+++ b/cmd/amd-suite/cmd.go
@@ -131,7 +131,16 @@ func (v *validatePSPEntriesCmd) Run(ctx *context) error {
 		return fmt.Errorf("could not extract keys from the firmware image: %w", err)
 	}
 
-	signatureValidations, err := psb.ValidatePSPEntries(amdFw, keyDB, directory, v.PSPEntries)
+	var pspEntryIDs []uint32
+	for _, pspEntry := range v.PSPEntries {
+		id, err := strconv.ParseInt(pspEntry, 16, 32)
+		if err != nil {
+			return fmt.Errorf("could not parse hexadecimal entry: %w", err)
+		}
+		pspEntryIDs = append(pspEntryIDs, uint32(id))
+	}
+
+	signatureValidations, err := psb.ValidatePSPEntries(amdFw, keyDB, directory, pspEntryIDs)
 	if err != nil {
 		return err
 	}

--- a/cmd/amd-suite/cmd.go
+++ b/cmd/amd-suite/cmd.go
@@ -22,10 +22,15 @@ type validatePSPEntriesCmd struct {
 	PSPEntries []string `arg required name:"validate-psp-entries" help:"Validates the signature of PSP entries given as argument." type:"list"`
 }
 
+type validateRTMCmd struct {
+	FwPath string `arg required name:"fwpath" help:"Path to UEFI firmware image." type:"path"`
+}
+
 var cli struct {
 	Debug              bool                  `help:"Enable debug mode"`
 	ShowKeys           showKeysCmd           `cmd help:"Shows all key known to the system, together with their origin"`
 	ValidatePSPEntries validatePSPEntriesCmd `cmd help:"Validates signatures of PSP entries"`
+	ValidateRTM        validateRTMCmd        `cmd help: Validated the signature of the extended RTM volume, which includes RTM and BIOS Directory Table`
 }
 
 func (s *showKeysCmd) Run(ctx *context) error {
@@ -59,4 +64,19 @@ func (v *validatePSPEntriesCmd) Run(ctx *context) error {
 	}
 	return nil
 
+}
+
+func (v *validateRTMCmd) Run(ctx *context) error {
+
+	firmware, err := uefi.ParseUEFIFirmwareFile(v.FwPath)
+	if err != nil {
+		return fmt.Errorf("could not parse firmware image: %w", err)
+	}
+
+	signatureValidation, err := psb.ValidateRTM(firmware)
+	if err != nil {
+		return err
+	}
+	fmt.Println(signatureValidation.String())
+	return nil
 }

--- a/cmd/amd-suite/cmd.go
+++ b/cmd/amd-suite/cmd.go
@@ -23,7 +23,7 @@ type showKeysCmd struct {
 type validatePSPEntriesCmd struct {
 	FwPath     string   `required name:"fwpath" help:"Path to UEFI firmware image." type:"path"`
 	PSPLevel   uint     `required name:"psp-level" help:"PSP Directory Level to use"`
-	PSPEntries []string `arg required name:"validate-psp-entries" help:"Validates the signature of PSP entries given as argument." type:"list"`
+	PSPEntries []string `arg required name:"psp-entries-hex-codes" help:"Hex codes of PSP entries to validate" type:"list"`
 }
 
 type validateRTMCmd struct {
@@ -33,17 +33,17 @@ type validateRTMCmd struct {
 
 type dumpPSPEntryCmd struct {
 	FwPath    string `required name:"fwpath" help:"Path to UEFI firmware image." type:"path"`
-	PSPEntry  string `required name:"dump_psp-entry" help:"dump PSP entry to system file." type:"string"`
 	PSPLevel  uint   `required name:"psp-level" help:"PSP Directory Level to use"`
-	EntryFile string `required name:"entry_path" help:"Path to entry file." type:"path"`
+	EntryFile string `required name:"entry-path" help:"Path to entry file." type:"path"`
+	PSPEntry  string `arg name:"psp-entry-hex-code" help:"Hex code of PSP entry to dump" type:"string"`
 }
 
 type patchPSPEntryCmd struct {
 	FwPath               string `required name:"fwpath" help:"Path to UEFI firmware image." type:"path"`
-	PSPEntry             string `required name:"patch-psp-entry" help:"dump PSP entry to system file." type:"string"`
 	PSPLevel             uint   `required name:"psp-level" help:"PSP Directory Level to use"`
-	EntryFile            string `required name:"modified_entry_path" help:"Path to modified entry file." type:"path"`
-	ModifiedFirmwareFile string `required name:"modified_fwpath" help:"Path to UEFI firmware modified image." type:"path"`
+	EntryFile            string `required name:"modified-entry-path" help:"Path to modified entry file." type:"path"`
+	ModifiedFirmwareFile string `required name:"modified-fwpath" help:"Path to UEFI firmware modified image." type:"path"`
+	PSPEntry             string `arg required name:"psp-entry-hex-code" help:"Hex code of PSP entry to patch" type:"string"`
 }
 
 var cli struct {

--- a/cmd/amd-suite/cmd.go
+++ b/cmd/amd-suite/cmd.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/9elements/converged-security-suite/v2/pkg/amd/apcb"
-	"github.com/9elements/converged-security-suite/v2/pkg/amd/psb"
+	"github.com/linuxboot/fiano/pkg/amd/apcb"
+	"github.com/linuxboot/fiano/pkg/amd/psb"
 
 	amd_manifest "github.com/linuxboot/fiano/pkg/amd/manifest"
 )
@@ -100,7 +100,7 @@ var cli struct {
 }
 
 func (s *outputFirmwareCmd) Run(ctx *context) error {
-	amdFw, err := psb.ParseAMDFirmwareFile(s.FwPath)
+	amdFw, err := parseAMDFirmwareFile(s.FwPath)
 	if err != nil {
 		return fmt.Errorf("could not parse firmware image: %w", err)
 	}
@@ -119,7 +119,7 @@ func (s *outputFirmwareCmd) Run(ctx *context) error {
 }
 
 func (s *showKeysCmd) Run(ctx *context) error {
-	amdFw, err := psb.ParseAMDFirmwareFile(s.FwPath)
+	amdFw, err := parseAMDFirmwareFile(s.FwPath)
 	if err != nil {
 		return fmt.Errorf("could not parse firmware image: %w", err)
 	}
@@ -139,7 +139,7 @@ func (v *validatePSPEntriesCmd) Run(ctx *context) error {
 		return err
 	}
 
-	amdFw, err := psb.ParseAMDFirmwareFile(v.FwPath)
+	amdFw, err := parseAMDFirmwareFile(v.FwPath)
 	if err != nil {
 		return fmt.Errorf("could not parse firmware image: %w", err)
 	}
@@ -170,7 +170,7 @@ func (v *validatePSPEntriesCmd) Run(ctx *context) error {
 }
 
 func (v *validateRTMCmd) Run(ctx *context) error {
-	amdFw, err := psb.ParseAMDFirmwareFile(v.FwPath)
+	amdFw, err := parseAMDFirmwareFile(v.FwPath)
 	if err != nil {
 		return fmt.Errorf("could not parse firmware image: %w", err)
 	}
@@ -186,7 +186,7 @@ func (v *validateRTMCmd) Run(ctx *context) error {
 func dumpHelper(fwPath string, entry string, resultFile string,
 	dump func(amdFw *amd_manifest.AMDFirmware, entryID uint32, w io.Writer) (int, error),
 ) error {
-	amdFw, err := psb.ParseAMDFirmwareFile(fwPath)
+	amdFw, err := parseAMDFirmwareFile(fwPath)
 	if err != nil {
 		return fmt.Errorf("could not parse firmware image: %w", err)
 	}
@@ -230,7 +230,7 @@ func (v *dumpBIOSEntryCmd) Run(ctx *context) error {
 func patchHelper(fwPath string, entry string, entryFile string, resultFile string,
 	patch func(amdFw *amd_manifest.AMDFirmware, entryID uint32, r io.Reader, w io.Writer) (int, error),
 ) error {
-	amdFw, err := psb.ParseAMDFirmwareFile(fwPath)
+	amdFw, err := parseAMDFirmwareFile(fwPath)
 	if err != nil {
 		return fmt.Errorf("could not parse firmware image: %w", err)
 	}
@@ -283,7 +283,7 @@ func (v *patchBIOSEntryCmd) Run(ctx *context) error {
 }
 
 func (v *outputAPCBSecurityTokensCmd) Run(ctx *context) error {
-	amdFw, err := psb.ParseAMDFirmwareFile(v.FwPath)
+	amdFw, err := parseAMDFirmwareFile(v.FwPath)
 	if err != nil {
 		return fmt.Errorf("could not parse firmware image: %w", err)
 	}

--- a/cmd/amd-suite/cmd.go
+++ b/cmd/amd-suite/cmd.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/9elements/converged-security-suite/v2/pkg/amd/psb"
+
+	"github.com/9elements/converged-security-suite/pkg/uefi"
 )
 
 // Context for kong command line parser
@@ -19,6 +23,10 @@ var cli struct {
 }
 
 func (s *showKeyDBCmd) Run(ctx *context) error {
-	psb.ShowKeyDB()
+	firmware, err := uefi.ParseUEFIFirmwareFile(s.FwPath)
+	if err != nil {
+		return fmt.Errorf("could not parse firmware image: %w", err)
+	}
+	psb.GetKeyDB(firmware)
 	return nil
 }

--- a/cmd/amd-suite/cmd.go
+++ b/cmd/amd-suite/cmd.go
@@ -27,6 +27,6 @@ func (s *showKeyDBCmd) Run(ctx *context) error {
 	if err != nil {
 		return fmt.Errorf("could not parse firmware image: %w", err)
 	}
-	psb.GetKeyDB(firmware)
-	return nil
+
+	return psb.GetKeyDB(firmware)
 }

--- a/cmd/amd-suite/cmd.go
+++ b/cmd/amd-suite/cmd.go
@@ -17,9 +17,15 @@ type showKeyDBCmd struct {
 	FwPath string `arg required name:"fwpath" help:"Path to UEFI firmware image." type:"path"`
 }
 
+type validatePSPEntriesCmd struct {
+	FwPath     string   `arg required name:"fwpath" help:"Path to UEFI firmware image." type:"path"`
+	PSPEntries []string `arg required name:"validate-psp-entries" help:"Validates the signature of PSP entries given as argument." type:"list"`
+}
+
 var cli struct {
-	Debug     bool         `help:"Enable debug mode"`
-	ShowKeyDB showKeyDBCmd `cmd help:"Shows content of Key Database"`
+	Debug              bool                  `help:"Enable debug mode"`
+	ShowKeyDB          showKeyDBCmd          `cmd help:"Shows content of Key Database"`
+	ValidatePSPEntries validatePSPEntriesCmd `cmd help:"Validates signatures of PSP entries"`
 }
 
 func (s *showKeyDBCmd) Run(ctx *context) error {
@@ -35,4 +41,22 @@ func (s *showKeyDBCmd) Run(ctx *context) error {
 
 	fmt.Println(keyDB.String())
 	return nil
+}
+
+func (v *validatePSPEntriesCmd) Run(ctx *context) error {
+	firmware, err := uefi.ParseUEFIFirmwareFile(v.FwPath)
+	if err != nil {
+		return fmt.Errorf("could not parse firmware image: %w", err)
+	}
+
+	signatureValidations, err := psb.ValidatePSPEntries(firmware, v.PSPEntries)
+	if err != nil {
+		return err
+	}
+
+	for _, validation := range signatureValidations {
+		fmt.Println(validation.String())
+	}
+	return nil
+
 }

--- a/cmd/amd-suite/cmd.go
+++ b/cmd/amd-suite/cmd.go
@@ -16,34 +16,34 @@ type context struct {
 }
 
 type showKeysCmd struct {
-	FwPath   string `arg required name:"fwpath" help:"Path to UEFI firmware image." type:"path"`
-	PSPLevel uint   `arg required name:"psp-level" help:"PSP Directory Level to use"`
+	FwPath   string `required name:"fwpath" help:"Path to UEFI firmware image." type:"path"`
+	PSPLevel uint   `required name:"psp-level" help:"PSP Directory Level to use"`
 }
 
 type validatePSPEntriesCmd struct {
-	FwPath     string   `arg required name:"fwpath" help:"Path to UEFI firmware image." type:"path"`
-	PSPLevel   uint     `arg required name:"psp-level" help:"PSP Directory Level to use"`
+	FwPath     string   `required name:"fwpath" help:"Path to UEFI firmware image." type:"path"`
+	PSPLevel   uint     `required name:"psp-level" help:"PSP Directory Level to use"`
 	PSPEntries []string `arg required name:"validate-psp-entries" help:"Validates the signature of PSP entries given as argument." type:"list"`
 }
 
 type validateRTMCmd struct {
-	FwPath    string `arg required name:"fwpath" help:"Path to UEFI firmware image." type:"path"`
-	BIOSLevel uint   `arg required name:"bios-level" help:"BIOS Directory Level to use"`
+	FwPath    string `required name:"fwpath" help:"Path to UEFI firmware image." type:"path"`
+	BIOSLevel uint   `required name:"bios-level" help:"BIOS Directory Level to use"`
 }
 
 type dumpPSPEntryCmd struct {
-	FwPath    string `arg required name:"fwpath" help:"Path to UEFI firmware image." type:"path"`
-	PSPEntry  string `arg required name:"dump_psp-entry" help:"dump PSP entry to system file." type:"string"`
-	PSPLevel  uint   `arg required name:"psp-level" help:"PSP Directory Level to use"`
-	EntryFile string `arg required name:"entry_path" help:"Path to entry file." type:"path"`
+	FwPath    string `required name:"fwpath" help:"Path to UEFI firmware image." type:"path"`
+	PSPEntry  string `required name:"dump_psp-entry" help:"dump PSP entry to system file." type:"string"`
+	PSPLevel  uint   `required name:"psp-level" help:"PSP Directory Level to use"`
+	EntryFile string `required name:"entry_path" help:"Path to entry file." type:"path"`
 }
 
 type patchPSPEntryCmd struct {
-	FwPath               string `arg required name:"fwpath" help:"Path to UEFI firmware image." type:"path"`
-	PSPEntry             string `arg required name:"patch-psp-entry" help:"dump PSP entry to system file." type:"string"`
-	PSPLevel             uint   `arg required name:"psp-level" help:"PSP Directory Level to use"`
-	EntryFile            string `arg required name:"modified_entry_path" help:"Path to modified entry file." type:"path"`
-	ModifiedFirmwareFile string `arg required name:"modified_fwpath" help:"Path to UEFI firmware modified image." type:"path"`
+	FwPath               string `required name:"fwpath" help:"Path to UEFI firmware image." type:"path"`
+	PSPEntry             string `required name:"patch-psp-entry" help:"dump PSP entry to system file." type:"string"`
+	PSPLevel             uint   `required name:"psp-level" help:"PSP Directory Level to use"`
+	EntryFile            string `required name:"modified_entry_path" help:"Path to modified entry file." type:"path"`
+	ModifiedFirmwareFile string `required name:"modified_fwpath" help:"Path to UEFI firmware modified image." type:"path"`
 }
 
 var cli struct {

--- a/cmd/amd-suite/cmd.go
+++ b/cmd/amd-suite/cmd.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/9elements/converged-security-suite/v2/pkg/amd/psb"
 
-	"github.com/9elements/converged-security-suite/pkg/uefi"
+	"github.com/9elements/converged-security-suite/v2/pkg/uefi"
 
-	amd_manifest "github.com/9elements/converged-security-suite/pkg/amd/manifest"
+	amd_manifest "github.com/9elements/converged-security-suite/v2/pkg/amd/manifest"
 )
 
 // Context for kong command line parser

--- a/cmd/amd-suite/main.go
+++ b/cmd/amd-suite/main.go
@@ -3,8 +3,6 @@ package main
 import (
 	"github.com/9elements/converged-security-suite/v2/pkg/log"
 	"github.com/alecthomas/kong"
-	"github.com/facebookincubator/go-belt/tool/logger"
-	"github.com/facebookincubator/go-belt/tool/logger/implementation/dummy"
 	fianoLog "github.com/linuxboot/fiano/pkg/log"
 )
 
@@ -25,7 +23,7 @@ func main() {
 			Compact: true,
 			Summary: true,
 		}))
-	fianoLog.DefaultLogger = log.NewFianoLogger(dummy.New(), logger.LevelPanic)
+	fianoLog.DefaultLogger = log.DummyLogger{}
 
 	// Run commands
 	err := ctx.Run(&context{

--- a/cmd/amd-suite/main.go
+++ b/cmd/amd-suite/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"github.com/9elements/converged-security-suite/v2/pkg/log"
 	"github.com/alecthomas/kong"
+	"github.com/facebookincubator/go-belt/tool/logger"
+	"github.com/facebookincubator/go-belt/tool/logger/implementation/dummy"
 	fianoLog "github.com/linuxboot/fiano/pkg/log"
 )
 
@@ -23,7 +25,7 @@ func main() {
 			Compact: true,
 			Summary: true,
 		}))
-	fianoLog.DefaultLogger = log.DummyLogger{}
+	fianoLog.DefaultLogger = log.NewFianoLogger(dummy.New(), logger.LevelPanic)
 
 	// Run commands
 	err := ctx.Run(&context{

--- a/cmd/amd-suite/main.go
+++ b/cmd/amd-suite/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"github.com/9elements/converged-security-suite/pkg/log"
+	"github.com/alecthomas/kong"
+	fianoLog "github.com/linuxboot/fiano/pkg/log"
+)
+
+const programName = "amd-suite"
+const programDesc = "AMD PSP and PSB management tool"
+
+var (
+	gitcommit string
+	gittag    string
+)
+
+func main() {
+	ctx := kong.Parse(&cli,
+		kong.Name(programName),
+		kong.Description(programDesc),
+		kong.UsageOnError(),
+		kong.ConfigureHelp(kong.HelpOptions{
+			Compact: true,
+			Summary: true,
+		}))
+	fianoLog.DefaultLogger = log.DummyLogger{}
+
+	// Run commands
+	err := ctx.Run(&context{
+		debug: cli.Debug})
+	ctx.FatalIfErrorf(err)
+}

--- a/cmd/amd-suite/main.go
+++ b/cmd/amd-suite/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/9elements/converged-security-suite/pkg/log"
+	"github.com/9elements/converged-security-suite/v2/pkg/log"
 	"github.com/alecthomas/kong"
 	fianoLog "github.com/linuxboot/fiano/pkg/log"
 )

--- a/cmd/amd-suite/parse_amd_firmware_file.go
+++ b/cmd/amd-suite/parse_amd_firmware_file.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/linuxboot/fiano/pkg/amd/manifest"
+)
+
+func parseAMDFirmwareFile(
+	filePath string,
+) (*manifest.AMDFirmware, error) {
+	b, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read file '%s': %w", filePath, err)
+	}
+
+	return manifest.NewAMDFirmware(manifest.FirmwareImage(b))
+}

--- a/go.mod
+++ b/go.mod
@@ -11,21 +11,27 @@ require (
 	github.com/facebookincubator/go-belt v0.0.0-20221130102226-a78fd808461b
 	github.com/fearful-symmetry/gomsr v0.0.1
 	github.com/golang-collections/go-datastructures v0.0.0-20150211160725-59788d5eb259
+	github.com/google/certificate-transparency-go v1.1.1
 	github.com/google/go-attestation v0.4.3
 	github.com/google/go-tpm v0.3.3
+	github.com/google/go-tspi v0.2.1-0.20190423175329-115dea689aad
 	github.com/google/uuid v1.3.0
+	github.com/intel-go/cpuid v0.0.0-20220614022739-219e067757cb
 	github.com/klauspost/cpuid/v2 v2.2.3
-	github.com/linuxboot/fiano v1.1.4-0.20230131115913-85ddba13ba44
+	github.com/linuxboot/fiano v1.1.4-0.20230509204726-c0f54661a4fe
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/marcoguerri/go-tpm-tcti v0.0.0-20210425104733-8e8c8fe68e60
 	github.com/steakknife/hamming v0.0.0-20180906055917-c99c65617cd3
 	github.com/stretchr/testify v1.8.1
 	github.com/tidwall/pretty v1.2.1
+	github.com/tjfoc/gmsm v1.4.1
 	github.com/ulikunitz/xz v0.5.11
 	github.com/xaionaro-facebook/go-dmidecode v0.0.0-20220413144237-c42d5bef2498
 	github.com/xaionaro-go/bytesextra v0.0.0-20220103144954-846e454ddea9
 	github.com/xaionaro-go/unsafetools v0.0.0-20210722164218-75ba48cf7b3c
 	golang.org/x/crypto v0.5.0
+	golang.org/x/sys v0.4.0
+	golang.org/x/text v0.6.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -35,16 +41,13 @@ require (
 	github.com/go-ng/sort v0.0.0-20220617173827-2cc7cd04f7c7 // indirect
 	github.com/go-ng/xsort v0.0.0-20220617174223-1d146907bccc // indirect
 	github.com/godbus/dbus/v5 v5.0.4 // indirect
-	github.com/google/certificate-transparency-go v1.1.1 // indirect
-	github.com/google/go-tspi v0.2.1-0.20190423175329-115dea689aad // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/intel-go/cpuid v0.0.0-20220614022739-219e067757cb // indirect
+	github.com/jedib0t/go-pretty/v6 v6.4.6 // indirect
+	github.com/mattn/go-runewidth v0.0.13 // indirect
+	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/tjfoc/gmsm v1.4.1 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
 	golang.org/x/exp v0.0.0-20220613132600-b0d781184e0d // indirect
-	golang.org/x/sys v0.4.0 // indirect
 	golang.org/x/term v0.4.0 // indirect
-	golang.org/x/text v0.6.0 // indirect
-	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,7 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/fearful-symmetry/gomsr v0.0.1 h1:m208RzdTApWVbv8a9kf78rdPLQe+BY9AxRb/nSbHxSA=
 github.com/fearful-symmetry/gomsr v0.0.1/go.mod h1:Qb/0Y7zwobP7v8Sji+M5mlL4N7Voyz5WaKXXRFPnLio=
+github.com/frankban/quicktest v1.13.1 h1:xVm/f9seEhZFL9+n5kv5XLrGwy6elc4V9v/XFY2vmd8=
 github.com/frankban/quicktest v1.13.1/go.mod h1:NeW+ay9A/U67EYXNFA1nPE8e/tnQv/09mUdL/ijj8og=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fullstorydev/grpcurl v1.6.0/go.mod h1:ZQ+ayqbKMJNhzLmbpCiurTVlaK2M/3nqZCxaQ2Ze/sM=
@@ -198,6 +199,7 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-tpm v0.1.2-0.20190725015402-ae6dd98980d4/go.mod h1:H9HbmUG2YgV/PHITkO7p6wxEEj/v5nlsVWIwumwH2NI=
 github.com/google/go-tpm v0.3.0/go.mod h1:iVLWvrPp/bHeEkxTFi9WG6K9w0iy2yIszHwZGHPbzAw=
 github.com/google/go-tpm v0.3.2/go.mod h1:j71sMBTfp3X5jPHz852ZOfQMUOf65Gb/Th8pRmp7fvg=
@@ -282,6 +284,8 @@ github.com/insomniacslk/dhcp v0.0.0-20211209223715-7d93572ebe8e/go.mod h1:h+MxyH
 github.com/intel-go/cpuid v0.0.0-20200819041909-2aa72927c3e2/go.mod h1:RmeVYf9XrPRbRc3XIx0gLYA8qOFvNoPOfaEZduRlEp4=
 github.com/intel-go/cpuid v0.0.0-20220614022739-219e067757cb h1:Fg0Y/RDZ6UPwl3o7/IzPbneDq8g9+gH6DPs42KFUsy8=
 github.com/intel-go/cpuid v0.0.0-20220614022739-219e067757cb/go.mod h1:RmeVYf9XrPRbRc3XIx0gLYA8qOFvNoPOfaEZduRlEp4=
+github.com/jedib0t/go-pretty/v6 v6.4.6 h1:v6aG9h6Uby3IusSSEjHaZNXpHFhzqMmjXcPq1Rjl9Jw=
+github.com/jedib0t/go-pretty/v6 v6.4.6/go.mod h1:Ndk3ase2CkQbXLLNf5QDHoYb6J9WtVfmHZu9n8rk2xs=
 github.com/jhump/protoreflect v1.6.1/go.mod h1:RZQ/lnuN+zqeRVpQigTwO6o0AJUkxbnSnpuG7toUTG4=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
@@ -304,6 +308,8 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.10.6/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.13.6 h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQxcgc=
+github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.3 h1:sxCkb+qR91z4vsqw4vGGZlDgPz3G7gjaLyK3V8y70BU=
 github.com/klauspost/cpuid/v2 v2.2.3/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
@@ -323,8 +329,8 @@ github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/letsencrypt/pkcs11key/v4 v4.0.0/go.mod h1:EFUvBDay26dErnNb70Nd0/VW3tJiIbETBPTl9ATXQag=
 github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/linuxboot/fiano v1.1.4-0.20230131115913-85ddba13ba44 h1:Hp7L8kitx3x2MEXmL5NqVLD2/lzGtjYJnNEmjWv1ado=
-github.com/linuxboot/fiano v1.1.4-0.20230131115913-85ddba13ba44/go.mod h1:1FwHUkd0fdHTvACyx6IdVn1GBAiS5mG2CM5b0nLMLxo=
+github.com/linuxboot/fiano v1.1.4-0.20230509204726-c0f54661a4fe h1:OC3qmH7gz6JoIgrLywyNheQZNx6Q/YuzCUTONJmvQzM=
+github.com/linuxboot/fiano v1.1.4-0.20230509204726-c0f54661a4fe/go.mod h1:HvBTukwQd5XqWHuwi/sdjK7ECnTvtbtPWC5Aj6K4iSQ=
 github.com/logrusorgru/aurora v2.0.3+incompatible h1:tOpm7WcpBTn4fjmVfgpQq0EfczGlG91VSDkswnjF5A8=
 github.com/logrusorgru/aurora v2.0.3+incompatible/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -344,6 +350,8 @@ github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.6/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
+github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-tty v0.0.3/go.mod h1:ihxohKRERHTVzN+aSVRwACLCeqIoZAWpoICkkvrWyR0=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mdlayher/ethernet v0.0.0-20190606142754-0394541c37b7/go.mod h1:U6ZQobyTjI/tJyq2HG+i/dfSoFUt8/aZCM+GKtmFk/Y=
@@ -389,10 +397,13 @@ github.com/orangecms/go-framebuffer v0.0.0-20200613202404-a0700d90c330/go.mod h1
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/getopt/v2 v2.1.0/go.mod h1:4NtW75ny4eBw9fO1bhtNdYTlZKYX5/tBLtsOpwKIKd0=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pierrec/lz4 v2.6.1+incompatible h1:9UY3+iC23yxF0UfGaYrGplQ+79Rg+h/q9FV9ix19jjM=
+github.com/pierrec/lz4 v2.6.1+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pierrec/lz4/v4 v4.1.14/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/profile v1.6.0/go.mod h1:qBsxPvzyUincmltOk6iyRVxHYg4adc0OFOv72ZdLa18=
 github.com/pkg/term v1.2.0-beta.2/go.mod h1:E25nymQcrSllhX42Ok8MRm1+hyBdHY0dCeiKZ9jpNGw=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -419,6 +430,8 @@ github.com/pseudomuto/protoc-gen-doc v1.3.2/go.mod h1:y5+P6n3iGrbKG+9O04V5ld71in
 github.com/pseudomuto/protokit v0.2.0/go.mod h1:2PdH30hxVHsup8KpBTOXTBeMVhJZVio3Q8ViKSAXT0Q=
 github.com/rck/unit v0.0.3/go.mod h1:jTOnzP4s1OjIP1vdxb4n76b23QPKS4EurYg7sYMr2DM=
 github.com/rekby/gpt v0.0.0-20200219180433-a930afbc6edc/go.mod h1:scrOqOnnHVKCHENvFw8k9ajCb88uqLQDA4BvuJNJ2ew=
+github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
+github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -465,6 +478,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
@@ -487,7 +501,6 @@ github.com/u-root/uio v0.0.0-20220204230159-dac05f7d2cb4/go.mod h1:LpEX5FO/cB+WF
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
-github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.11 h1:kpFauv27b6ynzBNT/Xy+1k+fK4WswhN/6PN5WhFAGw8=
 github.com/ulikunitz/xz v0.5.11/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
@@ -511,6 +524,7 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.4/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
@@ -620,6 +634,7 @@ golang.org/x/net v0.0.0-20201010224723-4f7140c49acb/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -635,6 +650,7 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -699,12 +715,16 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210925032602-92d5a993a665/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
 golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210916214954-140adaaadfaf/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.4.0 h1:O7UWfv5+A2qiuulQk30kVinPoMtoIPeVaKLEgLpVkvg=
 golang.org/x/term v0.4.0/go.mod h1:9P2UbLfCdcvo3p/nzKvsmas4TnlujnuoV9hGgYzW1lQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -771,6 +791,7 @@ golang.org/x/tools v0.0.0-20200630154851-b2d8b0336632/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200706234117-b22de6825cf7/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.1.11-0.20220322213029-87a8611856c1/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E=
 golang.org/x/tools v0.1.11/go.mod h1:SgwaegtQh8clINPpECJMqnxLv9I09HLqnW3RMqW0CA4=
+golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
```
[xaionaro@void converged-security-suite]$ go run ./cmd/amd-suite/
Usage: amd-suite <command>

AMD PSP and PSB management tool

Flags:
  -h, --help     Show context-sensitive help.
      --debug    Enable debug mode

Commands:
  show-keys                       Shows all key known to the system, together with their origin
  validate-psp-entries            Validates signatures of PSP entries
  validate-rtm
  output-firmware                 Outputs information about the firmware and PSP/BIOS structure
  dump-psp-entry                  Dump an entry from PSP Directory to a file on the filesystem
  dump-bios-entry                 Dump an entry from BIOS Directory to a file on the filesystem
  patch-psp-entry                 take a path on the filesystem pointing to a dump of an PSP entry and re-apply it to the firmware
  patch-bios-entry                take a path on the filesystem pointing to a dump of an BIOS entry and re-apply it to the firmware
  output-security-tokens-entry    output security tokens of all APCB (including backup) entries in specified BIOS directory
  set-security-token              sets a APCB security token

Run "amd-suite <command> --help" for more information on a command.

amd-suite: error: expected one of "show-keys",  "validate-psp-entries",  "validate-rtm",  "output-firmware",  "dump-psp-entry",  ...
exit status 1
```