### PR TITLE
README.md: fix instruction link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Developer notes
 ---------------
 
 If you need to update a Boot Policy Manifest or a Key Manifest then please
-read an [instruction](./pkg/intel/metadata/manifest/README.md).
+read an
+[instruction](https://github.com/linuxboot/fiano/blob/main/pkg/intel/metadata/README.md).
 
 Funding
 --------------


### PR DESCRIPTION
It seems linuxboot/fiano is ised instead since:
e2a02949f40b195e5545996096f1e1d68bd79c3d