### PR TITLE
chore: fix build commands in documentation

### DIFF
--- a/cmd/core/bg-prov/README.md
+++ b/cmd/core/bg-prov/README.md
@@ -30,7 +30,7 @@ Verify all downloaded dependencies run:
 To build the test suite run:
 
 ```
-<GO111MODULE=on> go build -o bg-prov cmd/bg-prov/*.go
+<GO111MODULE=on> go build -o bg-prov cmd/core/bg-prov/*.go
 ```
 
 Commandline subcommands:

--- a/cmd/core/txt-prov/README.md
+++ b/cmd/core/txt-prov/README.md
@@ -33,7 +33,7 @@ Verify all downloaded dependencies run:
 To build the test suite run:
 
 ```
-<GO111MODULE=on> go build -o txt-prov cmd/txt-prov/*.go
+<GO111MODULE=on> go build -o txt-prov cmd/core/txt-prov/*.go
 ```
 
 Create a configuration file:

--- a/cmd/core/txt-suite/README.md
+++ b/cmd/core/txt-suite/README.md
@@ -73,7 +73,7 @@ Verify all downloaded dependencies run:
 To build the test suite run:
 
 ```
-<GO111MODULE=on> go build -o txt-suite cmd/txt-suite/*.go
+<GO111MODULE=on> go build -o txt-suite cmd/core/txt-suite/*.go
 ```
 
 Create a configuration file:

--- a/cmd/exp/pcr0tool/README.md
+++ b/cmd/exp/pcr0tool/README.md
@@ -71,7 +71,7 @@ Verify all downloaded dependencies run:
 To build the test suite run:
 
 ```
-<GO111MODULE=on> go build -o pcr0tool cmd/pcr0tool/
+<GO111MODULE=on> go build -o pcr0tool cmd/exp/pcr0tool/
 ```
 
 ## Functions


### PR DESCRIPTION
The https://github.com/9elements/converged-security-suite/pull/388 hass reorganized directories, without updating documentation.