### PR TITLE
go.mod: update go-linux-lowlevel-hw

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/9elements/converged-security-suite/v2
 
-go 1.24.0
+go 1.24.12
 
 require (
-	github.com/9elements/go-linux-lowlevel-hw v0.0.0-20240812193855-7e0a5df7e2d0
+	github.com/9elements/go-linux-lowlevel-hw v1.0.5-0.20260217195309-8b54f7428e51
 	github.com/alecthomas/kong v0.7.1
 	github.com/bxcodec/faker v2.0.1+incompatible
 	github.com/davecgh/go-spew v1.1.1
@@ -30,14 +30,14 @@ require (
 	github.com/xaionaro-go/bytesextra v0.0.0-20220103144954-846e454ddea9
 	github.com/xaionaro-go/unhash v0.0.0-20230427202706-0195a574c620
 	github.com/xaionaro-go/unsafetools v0.0.0-20210722164218-75ba48cf7b3c
-	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df
+	golang.org/x/exp v0.0.0-20240222234643-814bf88cf225
 	golang.org/x/term v0.37.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/DataDog/gostackparse v0.6.0 // indirect
-	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/go-ng/sort v0.0.0-20220617173827-2cc7cd04f7c7 // indirect
 	github.com/go-ng/xatomic v0.0.0-20230519181013-85c0ec87e55f // indirect
 	github.com/go-ng/xsort v0.0.0-20220617174223-1d146907bccc // indirect
@@ -48,10 +48,12 @@ require (
 	github.com/intel-go/cpuid v0.0.0-20220614022739-219e067757cb // indirect
 	github.com/jedib0t/go-pretty/v6 v6.4.6 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
+	github.com/micgor32/go-msr v0.0.0-20260216140510-4af4a85b8dc7 // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/tjfoc/gmsm v1.4.1 // indirect
+	github.com/u-root/cpuid v0.0.0 // indirect
 	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/sync v0.18.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ contrib.go.opencensus.io/resource v0.1.1/go.mod h1:F361eGI91LCmW1I/Saf+rX0+OFcig
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/9elements/go-linux-lowlevel-hw v0.0.0-20240812193855-7e0a5df7e2d0 h1:QkhlY4jC50SFbqc9YGNdPmcekSR3hIspGTIGr9nr2aI=
 github.com/9elements/go-linux-lowlevel-hw v0.0.0-20240812193855-7e0a5df7e2d0/go.mod h1:4aGFVjnPLsC83PKysZc3u8kUu5kPrV8wbrE5mL72kLw=
+github.com/9elements/go-linux-lowlevel-hw v1.0.5-0.20260217195309-8b54f7428e51 h1:Jnz/J8hHJazFkNoQznVt5Uy5yAXg50Hp0t0Pc5eHAR0=
+github.com/9elements/go-linux-lowlevel-hw v1.0.5-0.20260217195309-8b54f7428e51/go.mod h1:EI2O4DG2V9XYO2JFSiMAVKaDgDjyHMr55g5YrmppPFY=
 github.com/Azure/azure-amqp-common-go/v2 v2.1.0/go.mod h1:R8rea+gJRuJR6QxTir/XuEd+YuKoUiazDC/N96FiDEU=
 github.com/Azure/azure-pipeline-go v0.2.1/go.mod h1:UGSo8XybXnIGZ3epmeBw7Jdz+HiUVpqIlpz/HKHylF4=
 github.com/Azure/azure-sdk-for-go v29.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
@@ -197,6 +199,8 @@ github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQ
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
@@ -540,6 +544,8 @@ github.com/mattn/go-shellwords v1.0.10/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lL
 github.com/mattn/go-zglob v0.0.1/go.mod h1:9fxibJccNxU2cnpIKLRRFA7zX7qhkJIQWBb449FYHOo=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
+github.com/micgor32/go-msr v0.0.0-20260216140510-4af4a85b8dc7 h1:iZ04F08zvQa5KScTsMnyUavVYrFzvYCMcfVD7rx0Nos=
+github.com/micgor32/go-msr v0.0.0-20260216140510-4af4a85b8dc7/go.mod h1:kk7JILzEiQxmOhhFi5BYrsL5Ih+t7QDaIq4SAjqaIp4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/pkcs11 v1.0.2/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
@@ -742,6 +748,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
 github.com/u-root/cpuid v0.0.0-20250320140348-cc5fe81d966c h1:0ghii+ZNd3GwoEMuzESLxXSGBk9jlRfWOOmkoBClopc=
 github.com/u-root/cpuid v0.0.0-20250320140348-cc5fe81d966c/go.mod h1:LnxcvBqTx9ehtEbNgAP+rtKYohCaeJ2Lzmo/FSchi30=
+github.com/u-root/cpuid v0.0.0 h1:A9eFi+//FIyc5+7iRSnsz+vkYVRH/NqiQIxyUjUa5uo=
+github.com/u-root/cpuid v0.0.0/go.mod h1:4cKsFal/qG5riWG/6IGedb2y53cl1xdcbSszYjM6IrY=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
@@ -874,6 +882,8 @@ golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMk
 golang.org/x/exp v0.0.0-20200331195152-e8c3332aa8e5/go.mod h1:4M0jN8W1tt0AVLNr8HDosyJCDCDuyL9N9+3m7wDWgKw=
 golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df h1:UA2aFVmmsIlefxMk29Dp2juaUSth8Pyn3Tq5Y5mJGME=
 golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
+golang.org/x/exp v0.0.0-20240222234643-814bf88cf225 h1:LfspQV/FYTatPTr/3HzIcmiUFH7PGP+OQ6mgDYo3yuQ=
+golang.org/x/exp v0.0.0-20240222234643-814bf88cf225/go.mod h1:CxmFvTBINI24O/j8iY7H1xHzx2i4OsyguNBmN/uPtqc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/pkg/hwapi/mock_pc.go
+++ b/pkg/hwapi/mock_pc.go
@@ -51,6 +51,10 @@ func (n pcmock) CPULogCount() uint32 {
 	return 0
 }
 
+func (n pcmock) CPUID(uint32, uint32) (uint32, uint32, uint32, uint32) {
+	return 0, 0, 0, 0
+}
+
 func (n pcmock) IsReservedInE820(start uint64, end uint64) (bool, error) {
 	return false, fmt.Errorf("not implemented")
 }
@@ -70,7 +74,7 @@ func (n pcmock) AddressRangesIsDMAProtected(first, end uint64) (bool, error) {
 	return false, fmt.Errorf("not implemented")
 }
 
-func (n pcmock) ReadMSR(msr int64) []uint64 {
+func (n pcmock) ReadMSR(msr int64) uint64 {
 	panic("not implemented")
 }
 
@@ -153,7 +157,7 @@ func (n pcmock) ReadHostBridgeDPR() (hwapi.DMAProtectedRange, error) {
 	return hwapi.DMAProtectedRange{}, fmt.Errorf("not implemented")
 }
 
-//MockPCReadMemory emulates a x86_64 platform memory map
+// MockPCReadMemory emulates a x86_64 platform memory map
 func MockPCReadMemory(addr uint64) byte {
 	mem := map[uint64][]byte{
 		0xFED30000: []byte{
@@ -342,7 +346,7 @@ func (n pcmock) PCIWriteConfigSpace(d hwapi.PCIDevice, off int, val interface{})
 	return fmt.Errorf("not implemented")
 }
 
-//GetPcMock returns APIInterfaces for mocking the hwapi used in unittests
+// GetPcMock returns APIInterfaces for mocking the hwapi used in unittests
 func GetPcMock(ReadMemoryFunc func(uint64) byte) hwapi.LowLevelHardwareInterfaces {
 	return pcmock{
 		ReadMemoryFunc,

--- a/pkg/provisioning/bootguard/me.go
+++ b/pkg/provisioning/bootguard/me.go
@@ -41,20 +41,17 @@ type BGInfo struct {
 // GetBGInfo reads Boot Guard msr during runtime
 func GetBGInfo(hw hwapi.LowLevelHardwareInterfaces) (*BGInfo, error) {
 	msr := hw.ReadMSR(BootGuardACMInfoMSR)
-	if msr == nil {
-		return nil, fmt.Errorf("can't read Boot Guard msr")
-	}
 	var bgi BGInfo
-	bgi.NEMEnabled = (msr[0]>>0)&1 != 0
-	bgi.TPMType = (msr[0] >> 1) & 3
-	bgi.TPMSuccess = (msr[0]>>3)&1 != 0
-	bgi.ForceAnchorBoot = (msr[0]>>4)&1 != 0
-	bgi.Measured = (msr[0]>>5)&1 != 0
-	bgi.Verified = (msr[0]>>6)&1 != 0
-	bgi.ModuleRevoked = (msr[0]>>7)&1 != 0
-	bgi.BootGuardCapability = (msr[0]>>32)&1 != 0
-	bgi.ServerTXTCapability = (msr[0]>>34)&1 != 0
-	bgi.NoResetSecretProtection = (msr[0]>>35)&1 != 0
+	bgi.NEMEnabled = (msr>>0)&1 != 0
+	bgi.TPMType = (msr >> 1) & 3
+	bgi.TPMSuccess = (msr>>3)&1 != 0
+	bgi.ForceAnchorBoot = (msr>>4)&1 != 0
+	bgi.Measured = (msr>>5)&1 != 0
+	bgi.Verified = (msr>>6)&1 != 0
+	bgi.ModuleRevoked = (msr>>7)&1 != 0
+	bgi.BootGuardCapability = (msr>>32)&1 != 0
+	bgi.ServerTXTCapability = (msr>>34)&1 != 0
+	bgi.NoResetSecretProtection = (msr>>35)&1 != 0
 	return &bgi, nil
 }
 


### PR DESCRIPTION
Fixes https://github.com/9elements/converged-security-suite/issues/406 and possibly https://github.com/9elements/converged-security-suite/issues/404.

Running `txt-suite exec-tests`:

```
INFO[0000] For more information about the documents and chapters, run: txt-suite -m
INFO[0000] All tests
INFO[0000] --------------------------------------------------
2026/03/20 09:20:32 string(rsdp.Signature[:]) = $
INFO[0000] 00 - Intel CPU                               : PASS
INFO[0000] 01 - Weybridge or later                      : PASS
INFO[0000] 02 - CPU supports TXT                        : PASS
INFO[0000] 03 - TXT register space accessible           : PASS
INFO[0000] 04 - CPU supports SMX                        : PASS
INFO[0000] 05 - CPU supports VMX                        : PASS
INFO[0000] 06 - IA32_FEATURE_CONTROL                    : PASS
INFO[0000] 07 - TXT not disabled by BIOS                : PASS
INFO[0000] 08 - BIOS ACM has run                        : FAIL                 (bootstatus register incorrect)
INFO[0000] 09 - IBB is trusted                          : FAIL                 (IBB not trusted)
INFO[0000] 10 - TXT registers are locked                : FAIL                 (TXT register space is NOT locked)
INFO[0000] 11 - IA32 debug interface is disabled        : FAIL                 (ia32 jtag isn't locked or disabled)
INFO[0000] 12 - TPM connection                          : INTERNAL_ERROR       (TPM device not available)
INFO[0000] 13 - TPM is present                          : DEPENDENCY_FAILED    (TPM connection failed)
INFO[0000] 14 - TPM NVRAM is locked                     : DEPENDENCY_FAILED    (TPM is present failed)
INFO[0000] 15 - PS Index has correct config             : DEPENDENCY_FAILED    (TPM is present failed)
INFO[0000] 16 - AUX Index has correct config            : DEPENDENCY_FAILED    (TPM is present failed)
INFO[0000] 17 - AUX Index has the correct hash          : DEPENDENCY_FAILED    (TPM is present failed)
INFO[0000] 18 - PO Index has correct config             : DEPENDENCY_FAILED    (TPM is present failed)
INFO[0000] 19 - PS index has valid LCP Policy           : DEPENDENCY_FAILED    (TPM is present failed)
INFO[0000] 20 - PO index has valid LCP Policy           : DEPENDENCY_FAILED    (TPM is present failed)
INFO[0000] 21 - PCR 0 is set correctly                  : DEPENDENCY_FAILED    (TPM is present failed)
INFO[0000] 22 - NPW mode is deactivated in PS policy    : DEPENDENCY_FAILED    (PS index has valid LCP Policy failed)
INFO[0000] 23 - TXT mode is valid                       : DEPENDENCY_FAILED    (PS index has valid LCP Policy failed)
INFO[0000] 24 - Valid FIT vector                        : FAIL                 (FitPointer must be in ValidFitRange)
INFO[0000] 25 - Valid FIT                               : DEPENDENCY_FAILED    (Valid FIT vector failed)
INFO[0000] 26 - Microcode update entry in FIT           : DEPENDENCY_FAILED    (Valid FIT failed)
INFO[0000] 27 - BIOS ACM entry in FIT                   : DEPENDENCY_FAILED    (Valid FIT failed)
INFO[0000] 28 - IBB entry in FIT                        : DEPENDENCY_FAILED    (Valid FIT failed)
INFO[0000] 29 - BIOS Policy entry in FIT                : DEPENDENCY_FAILED    (TXT mode is valid failed)
INFO[0000] 30 - IBB covers reset vector                 : DEPENDENCY_FAILED    (IBB entry in FIT failed)
INFO[0000] 31 - IBB covers FIT vector                   : DEPENDENCY_FAILED    (IBB entry in FIT failed)
INFO[0000] 32 - IBB covers FIT                          : DEPENDENCY_FAILED    (IBB entry in FIT failed)
INFO[0000] 33 - IBBs doesn't overlap each other         : DEPENDENCY_FAILED    (IBB entry in FIT failed)
INFO[0000] 34 - BIOS ACM does not overlap IBBs          : DEPENDENCY_FAILED    (BIOS ACM entry in FIT failed)
INFO[0000] 35 - IBB and BIOS ACM below 4GiB             : DEPENDENCY_FAILED    (BIOS ACM entry in FIT failed)
INFO[0000] 36 - TXT not disabled by LCP Policy          : DEPENDENCY_FAILED    (Valid FIT failed)
INFO[0000] 37 - BIOSACM header valid                    : DEPENDENCY_FAILED    (BIOS ACM entry in FIT failed)
INFO[0000] 38 - BIOSACM size check                      : DEPENDENCY_FAILED    (BIOS ACM entry in FIT failed)
INFO[0000] 39 - BIOSACM alignment check                 : DEPENDENCY_FAILED    (BIOS ACM entry in FIT failed)
INFO[0000] 40 - BIOSACM matches chipset                 : DEPENDENCY_FAILED    (BIOS ACM entry in FIT failed)
INFO[0000] 41 - BIOSACM matches processor               : DEPENDENCY_FAILED    (BIOS ACM entry in FIT failed)
INFO[0000] 42 - SINIT/BIOS ACM has no NPW flag set      : DEPENDENCY_FAILED    (BIOS ACM entry in FIT failed)
INFO[0000] 43 - SINIT ACM supports used TPM             : DEPENDENCY_FAILED    (BIOS ACM entry in FIT failed)
INFO[0000] 44 - TXT heap ranges valid                   : PASS
INFO[0000] 45 - TXT public area reserved in e820        : PASS
INFO[0000] 46 - TXT private area reserved in e820       : PASS
INFO[0000] 47 - TXT memory reserved in e820             : PASS
INFO[0000] 48 - MMIO TPMDecode space reserved in e820   : PASS
INFO[0000] 49 - TXT memory in a DMA protected range     : FAIL                 (TXT heap region must end at top of DPR region)
INFO[0000] 50 - TXT DPR register locked                 : PASS
INFO[0000] 51 - CPU DPR equals hostbridge DPR           : PASS
INFO[0000] 52 - CPU hostbridge DPR register locked      : PASS
INFO[0000] 53 - TXT region contains SINIT ACM           : FAIL                 (unknown ACM header version: 0x682AB40D)
INFO[0000] 54 - SINIT ACM matches chipset               : DEPENDENCY_FAILED    (TXT region contains SINIT ACM failed)
INFO[0000] 55 - SINIT ACM matches CPU                   : DEPENDENCY_FAILED    (TXT region contains SINIT ACM failed)
INFO[0000] 56 - SINIT ACM startup successful            : FAIL                 (SINIT Error detected)
INFO[0000] 57 - BIOS DATA REGION present                : PASS
INFO[0000] 58 - BIOS DATA REGION valid                  : PASS
INFO[0000] 59 - CPU supports MTRRs                      : PASS
INFO[0000] 60 - CPU supports SMRRs                      : PASS
INFO[0000] 61 - SMRR covers SMM memory                  : FAIL                 (TSEG limit register isn't valid)
INFO[0000] 62 - SMRR protection active                  : PASS
INFO[0000] 63 - IOMMU/VT-d active                       : FAIL                 (failed to check SMRR DMA protection: no IOMMU found: /sys/class/iommu/*/intel-iommu/address does not exists or is malformed)
INFO[0000] 64 - TXT server mode enabled                 : PASS
INFO[0000] 65 - ACPI RSDP exists and has valid checksum : PASS
INFO[0000] 66 - ACPI MCFG is present                    : PASS
INFO[0000] 67 - ACPI DMAR is present                    : PASS
INFO[0000] 68 - ACPI DMAR is valid                      : PASS
INFO[0000] 69 - ACPI MADT is present                    : PASS
INFO[0000] 70 - ACPI MADT is valid                      : PASS
INFO[0000] 72 - ACPI RSDT is valid                      : PASS
INFO[0000] 73 - ACPI XSDT present                       : PASS
INFO[0000] 74 - ACPI XSDT is valid                      : PASS
INFO[0000] 75 - ACPI RSDT or XSDT is valid              : PASS
txt-suite: error: tests ran with errors
```

Why I think it also fixes #404. This test unlike previous one was done on QEMU as I don't have platform I can test this on currently.

Output of `bg-suite exec-tests --set=5,6,7 -f coreboot.rom` On `2.8.2` :

```
INFO[0000] Custom Set tests
INFO[0000] --------------------------------------------------
ReadMSR - msrCtx.Read aborted with: input/output error
INFO[0000] 00 - [RUNTIME] Validates Intel ME specific configuration against KM/BPM in firmware image: FAIL                 (bootguard km/bpm doesn't match ME BootGuard configuration: km svn doesn't match me configuration)
INFO[0000] 01 - [RUNTIME] Verifies Intel ME Boot Guard configuration is sane and safe: FAIL                 (can't read Boot Guard msr)
INFO[0000] 02 - [RUNTIME] BtG/TXT registers are sane    : FAIL                 (txt regs aren't valid: ACM status is invalid)
bg-suite: error: tests ran with errors
```

And with my changes (no `ReadMSR` error):

```
INFO[0000] Custom Set tests
INFO[0000] --------------------------------------------------
INFO[0000] 00 - [RUNTIME] Validates Intel ME specific configuration against KM/BPM in firmware image: FAIL                 (bootguard km/bpm doesn't match ME BootGuard configuration: km svn doesn't match me configuration)
INFO[0000] 01 - [RUNTIME] Verifies Intel ME Boot Guard configuration is sane and safe: FAIL                 (provisiong boot guard configuraton in me isn't safe: FPF isn't locked)
INFO[0000] 02 - [RUNTIME] BtG/TXT registers are sane    : FAIL                 (txt regs aren't valid: ACM status is invalid)
bg-suite: error: tests ran with errors
```