### PR TITLE
ci: fix liner errors

### DIFF
--- a/cmd/core/bg-prov/cmd.go
+++ b/cmd/core/bg-prov/cmd.go
@@ -313,7 +313,10 @@ func (kmp *kmPrintCmd) Run(ctx *context) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() {
+		err := file.Close()
+		log.Warnf("failed to close the file: %v\n", err)
+	}()
 	bg, err := bootguard.NewKM(file)
 	if err != nil {
 		return err
@@ -327,7 +330,10 @@ func (bpmp *bpmPrintCmd) Run(ctx *context) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() {
+		err := file.Close()
+		log.Warnf("failed to close the file: %v\n", err)
+	}()
 	bg, err := bootguard.NewBPM(file)
 	if err != nil {
 		return err
@@ -341,7 +347,10 @@ func (acmp *acmPrintCmd) Run(ctx *context) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() {
+		err := file.Close()
+		log.Warnf("failed to close the file: %v\n", err)
+	}()
 	acm, err := tools.ParseACM(file)
 	if err != nil {
 		return err
@@ -854,7 +863,10 @@ func (s *signKMCmd) Run(ctx *context) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() {
+		err := file.Close()
+		log.Warnf("failed to close the file: %v\n", err)
+	}()
 	bg, err := bootguard.NewKM(file)
 	if err != nil {
 		return err
@@ -882,7 +894,10 @@ func (s *signBPMCmd) Run(ctx *context) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() {
+		err := file.Close()
+		log.Warnf("failed to close the file: %v\n", err)
+	}()
 	bg, err := bootguard.NewBPM(file)
 	if err != nil {
 		return err
@@ -954,8 +969,10 @@ func (t *templateCmdv2) Run(ctx *context) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
-
+	defer func() {
+		err := f.Close()
+		log.Warnf("failed to close the file: %v\n", err)
+	}()
 	if err := bootguard.WriteJSON(f); err != nil {
 		return err
 	}
@@ -996,7 +1013,10 @@ func (t *templateCmdv1) Run(ctx *context) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() {
+		err := f.Close()
+		log.Warnf("failed to close the file: %v\n", err)
+	}()
 
 	if err := bootguard.WriteJSON(f); err != nil {
 		return err
@@ -1022,7 +1042,10 @@ func (s *stitchingKMCmd) Run(ctx *context) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() {
+		err := file.Close()
+		log.Warnf("failed to close the file: %v\n", err)
+	}()
 	sig, err := os.ReadFile(s.Signature)
 	if err != nil {
 		return err
@@ -1053,7 +1076,10 @@ func (s *stitchingBPMCmd) Run(ctx *context) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() {
+		err := file.Close()
+		log.Warnf("failed to close the file: %v\n", err)
+	}()
 	sig, err := os.ReadFile(s.Signature)
 	if err != nil {
 		return err
@@ -1124,7 +1150,10 @@ func (s *stitchingCmd) Run(ctx *context) error {
 		if err != nil {
 			return err
 		}
-		defer file.Close()
+		defer func() {
+			err := file.Close()
+			log.Warnf("failed to close the file: %v\n", err)
+		}()
 		size, err := file.WriteAt(me, int64(meRegionOffset))
 		if err != nil {
 			return err
@@ -1200,7 +1229,10 @@ func (v *verifyKMSigCmd) Run(ctx *context) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() {
+		err := file.Close()
+		log.Warnf("failed to close the file: %v\n", err)
+	}()
 	bg, err := bootguard.NewKM(file)
 	if err != nil {
 		return err
@@ -1213,7 +1245,10 @@ func (b *verifyBPMSigCmd) Run(ctx *context) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() {
+		err := file.Close()
+		log.Warnf("failed to close the file: %v\n", err)
+	}()
 	bg, err := bootguard.NewBPM(file)
 	if err != nil {
 		return err

--- a/cmd/core/bg-prov/cmd.go
+++ b/cmd/core/bg-prov/cmd.go
@@ -314,8 +314,9 @@ func (kmp *kmPrintCmd) Run(ctx *context) error {
 		return err
 	}
 	defer func() {
-		err := file.Close()
-		log.Warnf("failed to close the file: %v\n", err)
+		if err := file.Close(); err != nil {
+			log.Warnf("failed to close the file: %v\n", err)
+		}
 	}()
 	bg, err := bootguard.NewKM(file)
 	if err != nil {
@@ -331,8 +332,9 @@ func (bpmp *bpmPrintCmd) Run(ctx *context) error {
 		return err
 	}
 	defer func() {
-		err := file.Close()
-		log.Warnf("failed to close the file: %v\n", err)
+		if err := file.Close(); err != nil {
+			log.Warnf("failed to close the file: %v\n", err)
+		}
 	}()
 	bg, err := bootguard.NewBPM(file)
 	if err != nil {
@@ -348,8 +350,9 @@ func (acmp *acmPrintCmd) Run(ctx *context) error {
 		return err
 	}
 	defer func() {
-		err := file.Close()
-		log.Warnf("failed to close the file: %v\n", err)
+		if err := file.Close(); err != nil {
+			log.Warnf("failed to close the file: %v\n", err)
+		}
 	}()
 	acm, err := tools.ParseACM(file)
 	if err != nil {
@@ -864,8 +867,9 @@ func (s *signKMCmd) Run(ctx *context) error {
 		return err
 	}
 	defer func() {
-		err := file.Close()
-		log.Warnf("failed to close the file: %v\n", err)
+		if err := file.Close(); err != nil {
+			log.Warnf("failed to close the file: %v\n", err)
+		}
 	}()
 	bg, err := bootguard.NewKM(file)
 	if err != nil {
@@ -895,8 +899,9 @@ func (s *signBPMCmd) Run(ctx *context) error {
 		return err
 	}
 	defer func() {
-		err := file.Close()
-		log.Warnf("failed to close the file: %v\n", err)
+		if err := file.Close(); err != nil {
+			log.Warnf("failed to close the file: %v\n", err)
+		}
 	}()
 	bg, err := bootguard.NewBPM(file)
 	if err != nil {
@@ -970,8 +975,9 @@ func (t *templateCmdv2) Run(ctx *context) error {
 		return err
 	}
 	defer func() {
-		err := f.Close()
-		log.Warnf("failed to close the file: %v\n", err)
+		if err := f.Close(); err != nil {
+			log.Warnf("failed to close the file: %v\n", err)
+		}
 	}()
 	if err := bootguard.WriteJSON(f); err != nil {
 		return err
@@ -1014,8 +1020,9 @@ func (t *templateCmdv1) Run(ctx *context) error {
 		return err
 	}
 	defer func() {
-		err := f.Close()
-		log.Warnf("failed to close the file: %v\n", err)
+		if err := f.Close(); err != nil {
+			log.Warnf("failed to close the file: %v\n", err)
+		}
 	}()
 
 	if err := bootguard.WriteJSON(f); err != nil {
@@ -1043,8 +1050,9 @@ func (s *stitchingKMCmd) Run(ctx *context) error {
 		return err
 	}
 	defer func() {
-		err := file.Close()
-		log.Warnf("failed to close the file: %v\n", err)
+		if err := file.Close(); err != nil {
+			log.Warnf("failed to close the file: %v\n", err)
+		}
 	}()
 	sig, err := os.ReadFile(s.Signature)
 	if err != nil {
@@ -1077,8 +1085,9 @@ func (s *stitchingBPMCmd) Run(ctx *context) error {
 		return err
 	}
 	defer func() {
-		err := file.Close()
-		log.Warnf("failed to close the file: %v\n", err)
+		if err := file.Close(); err != nil {
+			log.Warnf("failed to close the file: %v\n", err)
+		}
 	}()
 	sig, err := os.ReadFile(s.Signature)
 	if err != nil {
@@ -1151,8 +1160,9 @@ func (s *stitchingCmd) Run(ctx *context) error {
 			return err
 		}
 		defer func() {
-			err := file.Close()
-			log.Warnf("failed to close the file: %v\n", err)
+			if err := file.Close(); err != nil {
+				log.Warnf("failed to close the file: %v\n", err)
+			}
 		}()
 		size, err := file.WriteAt(me, int64(meRegionOffset))
 		if err != nil {
@@ -1230,8 +1240,9 @@ func (v *verifyKMSigCmd) Run(ctx *context) error {
 		return err
 	}
 	defer func() {
-		err := file.Close()
-		log.Warnf("failed to close the file: %v\n", err)
+		if err := file.Close(); err != nil {
+			log.Warnf("failed to close the file: %v\n", err)
+		}
 	}()
 	bg, err := bootguard.NewKM(file)
 	if err != nil {
@@ -1246,8 +1257,9 @@ func (b *verifyBPMSigCmd) Run(ctx *context) error {
 		return err
 	}
 	defer func() {
-		err := file.Close()
-		log.Warnf("failed to close the file: %v\n", err)
+		if err := file.Close(); err != nil {
+			log.Warnf("failed to close the file: %v\n", err)
+		}
 	}()
 	bg, err := bootguard.NewBPM(file)
 	if err != nil {

--- a/cmd/core/txt-prov/cmd.go
+++ b/cmd/core/txt-prov/cmd.go
@@ -62,7 +62,10 @@ func (a *auxDeleteCmd) Run(ctx *context) error {
 	if err != nil {
 		return err
 	}
-	defer tpm.Close()
+	defer func() {
+		err := tpm.Close()
+		fmt.Printf("warning: failed to close the file: %v\n", err)
+	}()
 
 	switch tpm.Version {
 	case hwapi.TPMVersion12:

--- a/cmd/core/txt-prov/cmd.go
+++ b/cmd/core/txt-prov/cmd.go
@@ -63,8 +63,9 @@ func (a *auxDeleteCmd) Run(ctx *context) error {
 		return err
 	}
 	defer func() {
-		err := tpm.Close()
-		fmt.Printf("warning: failed to close the file: %v\n", err)
+		if err := tpm.Close(); err != nil {
+			fmt.Printf("warning: failed to close the file: %v\n", err)
+		}
 	}()
 
 	switch tpm.Version {

--- a/cmd/core/txt-suite/cmd.go
+++ b/cmd/core/txt-suite/cmd.go
@@ -178,7 +178,11 @@ func run(testGroup string, tests []*test.Test, preset *test.PreSet, interactive 
 			}
 		}
 		data, _ := json.MarshalIndent(t, "", "")
-		os.WriteFile(logfile, data, 0o664)
+		err := os.WriteFile(logfile, data, 0o664)
+		if err != nil {
+			log.Errorf("failed to write to file: %v\n", err)
+			return false
+		}
 	}
 
 	for index := range tests {

--- a/cmd/exp/pcr0tool/commands/bruteforce_acm_policy_status/command.go
+++ b/cmd/exp/pcr0tool/commands/bruteforce_acm_policy_status/command.go
@@ -190,7 +190,10 @@ func (cmd Command) Execute(ctx context.Context, args []string) {
 			ctx.tpmCommands[commandIdx].(*tpm.CommandExtend).Digest = newDigest[:]
 
 			ctx.tpm.Reset()
-			ctx.tpm.TPMExecute(context.Background(), ctx.tpmCommands, nil)
+			err := ctx.tpm.TPMExecute(context.Background(), ctx.tpmCommands, nil)
+			if err != nil {
+				panic(err)
+			}
 
 			// is it OK?
 			return bytes.Equal(ctx.tpm.PCRValues[0][tpm2.AlgSHA1], expectedHash)

--- a/cmd/exp/pcr0tool/commands/sum/command.go
+++ b/cmd/exp/pcr0tool/commands/sum/command.go
@@ -147,8 +147,9 @@ func (cmd Command) Execute(ctx context.Context, args []string) {
 			panic(err)
 		}
 		defer func() {
-			err := eventLogFile.Close()
-			logger.Errorf(ctx, "failed to close the file: %v\n", err)
+			if err := eventLogFile.Close(); err != nil {
+				logger.Errorf(ctx, "failed to close the file: %v\n", err)
+			}
 		}()
 
 		parsedEventLog, err := tpmeventlog.Parse(eventLogFile)

--- a/cmd/exp/pcr0tool/commands/sum/command.go
+++ b/cmd/exp/pcr0tool/commands/sum/command.go
@@ -146,7 +146,10 @@ func (cmd Command) Execute(ctx context.Context, args []string) {
 		if err != nil {
 			panic(err)
 		}
-		defer eventLogFile.Close()
+		defer func() {
+			err := eventLogFile.Close()
+			logger.Errorf(ctx, "failed to close the file: %v\n", err)
+		}()
 
 		parsedEventLog, err := tpmeventlog.Parse(eventLogFile)
 		if err != nil {
@@ -423,7 +426,11 @@ func printReproducePCR0Result(
 			return
 		}
 	}
-	resultCommandLog.Commands().Apply(ctx, dummyTPM)
+	err := resultCommandLog.Commands().Apply(ctx, dummyTPM)
+	if err != nil {
+		logger.Error(ctx, err)
+		return
+	}
 	replayedPCR0, err := dummyTPM.PCRValues.Get(0, hashAlgo)
 	if err != nil {
 		logger.Error(ctx, err)

--- a/pkg/bootflow/actions/amdactions/set_psp_verified.go
+++ b/pkg/bootflow/actions/amdactions/set_psp_verified.go
@@ -24,7 +24,7 @@ func SetPSPVerified(
 
 // Apply implements types.Action.
 func (s *SetPSPVerifiedType) Apply(ctx context.Context, state *types.State) error {
-	data, err := s.DataSource.Data(ctx, state)
+	data, err := s.Data(ctx, state)
 	if err != nil {
 		return fmt.Errorf("unable to extract the data: %w", err)
 	}

--- a/pkg/bootflow/actions/intelactions/set_pch_verified.go
+++ b/pkg/bootflow/actions/intelactions/set_pch_verified.go
@@ -24,7 +24,7 @@ func SetPCHVerified(
 
 // Apply implements types.Action.
 func (s *SetPCHVerifiedT) Apply(ctx context.Context, state *types.State) error {
-	data, err := s.DataSource.Data(ctx, state)
+	data, err := s.Data(ctx, state)
 	if err != nil {
 		return fmt.Errorf("unable to extract the data: %w", err)
 	}

--- a/pkg/bootflow/bootengine/log.go
+++ b/pkg/bootflow/bootengine/log.go
@@ -99,9 +99,9 @@ type ErroredSteps []*StepResult
 func (s ErroredSteps) Error() string {
 	var result strings.Builder
 	for _, step := range s {
-		result.WriteString(fmt.Sprintf("step %s:\n", step))
+		fmt.Fprintf(&result, "step %s:\n", step)
 		for _, issue := range step.Issues {
-			result.WriteString(fmt.Sprintf("\t%s: %v\n", issue.Coords, issue.Issue))
+			fmt.Fprintf(&result, "\t%s: %v\n", issue.Coords, issue.Issue)
 		}
 	}
 	return result.String()

--- a/pkg/bootflow/bootengine/validator/validator_actors_are_protected.go
+++ b/pkg/bootflow/bootengine/validator/validator_actors_are_protected.go
@@ -44,7 +44,7 @@ func (ValidatorActorsAreProtected) Validate(_ context.Context, _ *types.State, l
 		if step.ActorCode == nil {
 			continue
 		}
-		actorRefs := step.ActorCode.References.Exclude() // a copy
+		actorRefs := step.ActorCode.Exclude() // a copy
 		if err := actorRefs.Resolve(); err != nil {
 			result = append(result, Issue{
 				StepIdx: uint(stepIdx),

--- a/pkg/bootflow/bootengine/validator/validator_final_coverage_is_complete.go
+++ b/pkg/bootflow/bootengine/validator/validator_final_coverage_is_complete.go
@@ -51,7 +51,7 @@ func (ValidatorFinalCoverageIsComplete) Validate(
 		}}
 	}
 
-	nonMeasured := data.References.Exclude(measured...)
+	nonMeasured := data.Exclude(measured...)
 	if len(nonMeasured) == 0 {
 		return nil
 	}

--- a/pkg/bootflow/conditions/biosconds/intelconds/valid_bpm.go
+++ b/pkg/bootflow/conditions/biosconds/intelconds/valid_bpm.go
@@ -44,7 +44,7 @@ func validateBPM(
 		return nil
 	}
 
-	if err := bpm.PMSE.KeySignature.Verify(bpmFIT.DataSegmentBytes[:bpm.KeySignatureOffset]); err != nil {
+	if err := bpm.PMSE.Verify(bpmFIT.DataSegmentBytes[:bpm.KeySignatureOffset]); err != nil {
 		return fmt.Errorf("unable to confirm KM signature: %w", err)
 	}
 

--- a/pkg/bootflow/datasources/volume_of.go
+++ b/pkg/bootflow/datasources/volume_of.go
@@ -67,7 +67,7 @@ func (v VolumeOfType) Data(ctx context.Context, s *types.State) (*types.Data, er
 
 			var volume *ffs.Node
 			for _, node := range nodes {
-				if node.Range.Offset == math.MaxUint64 {
+				if node.Offset == math.MaxUint64 {
 					continue
 				}
 				if _, ok := node.Firmware.(*uefi.FirmwareVolume); ok {

--- a/pkg/bootflow/subsystems/trustchains/tpm/command.go
+++ b/pkg/bootflow/subsystems/trustchains/tpm/command.go
@@ -89,7 +89,7 @@ func (s CommandLog) Commands() Commands {
 func (s CommandLog) String() string {
 	var result strings.Builder
 	for idx, e := range s {
-		result.WriteString(fmt.Sprintf("%d. %s\n", idx, format.NiceString(e)))
+		fmt.Fprintf(&result, "%d. %s\n", idx, format.NiceString(e))
 	}
 	return result.String()
 }

--- a/pkg/bootflow/subsystems/trustchains/tpm/command.go
+++ b/pkg/bootflow/subsystems/trustchains/tpm/command.go
@@ -58,7 +58,7 @@ type CommandLogEntry struct {
 
 // String implements fmt.Stringer.
 func (entry CommandLogEntry) String() string {
-	return entry.Command.LogString()
+	return entry.LogString()
 }
 
 func newCommandLogEntry(

--- a/pkg/bootflow/subsystems/trustchains/tpm/pcrbruteforcer/reproduce_event_log.go
+++ b/pkg/bootflow/subsystems/trustchains/tpm/pcrbruteforcer/reproduce_event_log.go
@@ -380,7 +380,7 @@ func getACMPolicyStatusRefFromMeasurement(
 	// We assume this is a PCR0_DATA/PCR7_DATA measurement if it measures ACM_POLICY_STATUS registers
 	// (and no other registers but ACM_POLICY_STATUS).
 
-	refs := m.References.BySystemArtifact(txtPublicRegisters)
+	refs := m.BySystemArtifact(txtPublicRegisters)
 	if len(refs) != 1 {
 		return nil
 	}

--- a/pkg/bootflow/subsystems/trustchains/tpm/pcrbruteforcer/reproduce_expected_pcr0.go
+++ b/pkg/bootflow/subsystems/trustchains/tpm/pcrbruteforcer/reproduce_expected_pcr0.go
@@ -548,7 +548,7 @@ func (j *orderBruteforcerJob) executeRecursive(
 }
 
 func isMeasurePCR0DATACmdLogEntry(logEntry *tpm.CommandLogEntry) bool {
-	_, ok := logEntry.CauseCoordinates.Step().(intelsteps.MeasurePCR0DATA)
+	_, ok := logEntry.Step().(intelsteps.MeasurePCR0DATA)
 	return ok
 }
 
@@ -589,7 +589,7 @@ func (j *reproduceExpectedPCR0Job) measurementsVerifyWithBruteForceACMPolicyStat
 		return nil, nil, fmt.Errorf("empty measurements slice, cannot compute PCR0")
 	}
 
-	_, ok := enabledMeasurements[0].CauseCoordinates.Step().(intelsteps.MeasurePCR0DATA)
+	_, ok := enabledMeasurements[0].Step().(intelsteps.MeasurePCR0DATA)
 	if !ok {
 		return nil, nil, fmt.Errorf("the first TPM command is not caused by a MeasurePCR0DATA step")
 	}

--- a/pkg/bootflow/subsystems/trustchains/tpm/pools.go
+++ b/pkg/bootflow/subsystems/trustchains/tpm/pools.go
@@ -34,6 +34,6 @@ func acquireHasher(algo tpm2.Algorithm) (*hasher, error) {
 }
 
 func releaseHasher(hasher *hasher) {
-	hasher.Hash.Reset()
+	hasher.Reset()
 	hasherPools[hasher.Algo].Put(hasher)
 }

--- a/pkg/bootflow/types/data.go
+++ b/pkg/bootflow/types/data.go
@@ -503,12 +503,12 @@ type MeasuredData struct {
 // String implements fmt.Stringer.
 func (d MeasuredData) String() string {
 	var result strings.Builder
-	result.WriteString(fmt.Sprintf("%s <- %v", typeMapKey(d.TrustChain).Name(), d.Data))
+	fmt.Fprintf(&result, "%s <- %v", typeMapKey(d.TrustChain).Name(), d.Data)
 	if d.DataSource != nil {
-		result.WriteString(fmt.Sprintf(" (%v)", d.DataSource))
+		fmt.Fprintf(&result, " (%v)", d.DataSource)
 	}
 	if d.Actor != nil {
-		result.WriteString(fmt.Sprintf(" [%T]", d.Actor))
+		fmt.Fprintf(&result, " [%T]", d.Actor)
 	}
 	return result.String()
 }

--- a/pkg/diff/analyze.go
+++ b/pkg/diff/analyze.go
@@ -340,16 +340,16 @@ type interval struct {
 }
 
 func (item *interval) LowAtDimension(_ uint64) int64 {
-	return int64(item.Range.Offset)
+	return int64(item.Offset)
 }
 
 func (item *interval) HighAtDimension(_ uint64) int64 {
-	return int64(item.Range.Offset + item.Range.Length)
+	return int64(item.Offset + item.Length)
 }
 
 func (item *interval) OverlapsAtDimension(cmpIface augmentedtree.Interval, _ uint64) bool {
 	cmp := cmpIface.(*interval)
-	return item.Range.Intersect(cmp.Range)
+	return item.Intersect(cmp.Range)
 }
 
 func (item *interval) ID() uint64 {
@@ -394,7 +394,7 @@ func newNamesIntervalTree(m map[string]pkgbytes.Ranges) intervalTree {
 
 func (t *intervalTree) FindOverlapping(r pkgbytes.Range) []interface{} {
 	var result []interface{}
-	for _, item := range t.Tree.Query(&interval{
+	for _, item := range t.Query(&interval{
 		Range: r,
 	}) {
 		result = append(result, item.(*interval).Value)

--- a/pkg/ostools/file_to_bytes.go
+++ b/pkg/ostools/file_to_bytes.go
@@ -15,7 +15,7 @@ func FileToBytes(filePath string) ([]byte, error) {
 		return nil, fmt.Errorf(`unable to open the image-file "%v": %w`,
 			filePath, err)
 	}
-	defer file.Close() // it was a read-only Open(), so we don't check the Close()
+	defer file.Close() //nolint:errcheck // it was a read-only Open(), so we don't check the Close()
 
 	// To consume less memory we use mmap() instead of reading the image
 	// into the memory. However these bytes are also parsed by

--- a/pkg/provisioning/bootguard/bootguard.go
+++ b/pkg/provisioning/bootguard/bootguard.go
@@ -1018,7 +1018,10 @@ func (b *BootGuard) CreateIBBSegments(seElement uint8, flags uint16, imagepath s
 	if err != nil {
 		return err
 	}
-	defer image.Close()
+	defer func() {
+		err := image.Close()
+		log.Warnf("failed to close the file: %v\n", err)
+	}()
 	stat, err := image.Stat()
 	if err != nil {
 		return err
@@ -1033,7 +1036,10 @@ func (b *BootGuard) CreateIBBSegments(seElement uint8, flags uint16, imagepath s
 	img, err := cbfs.NewImage(image)
 	if err != nil {
 		// To be sure the image file is closed before reading from it again
-		image.Close()
+		err := image.Close()
+		if err != nil {
+			return err
+		}
 		img, err := os.ReadFile(imagepath)
 		if err != nil {
 			return err

--- a/pkg/provisioning/bootguard/bootguard.go
+++ b/pkg/provisioning/bootguard/bootguard.go
@@ -394,7 +394,7 @@ func (b *BootGuard) StitchBPM(pubKey crypto.PublicKey, signature []byte) ([]byte
 	switch b.Version {
 	case bgheader.Version10:
 		b.VData.BGbpm.PMSE = *bgbootpolicy.NewSignature()
-		if err := b.VData.BGbpm.PMSE.KeySignature.FillSignature(0, pubKey, signature, bg.AlgNull); err != nil {
+		if err := b.VData.BGbpm.PMSE.FillSignature(0, pubKey, signature, bg.AlgNull); err != nil {
 			return nil, err
 		}
 
@@ -404,7 +404,7 @@ func (b *BootGuard) StitchBPM(pubKey crypto.PublicKey, signature []byte) ([]byte
 		}
 	case bgheader.Version20:
 		b.VData.CBNTbpm.PMSE = *cbntbootpolicy.NewSignature()
-		if err := b.VData.CBNTbpm.PMSE.KeySignature.FillSignature(0, pubKey, signature, cbnt.AlgNull); err != nil {
+		if err := b.VData.CBNTbpm.PMSE.FillSignature(0, pubKey, signature, cbnt.AlgNull); err != nil {
 			return nil, err
 		}
 

--- a/pkg/provisioning/bootguard/bootguard.go
+++ b/pkg/provisioning/bootguard/bootguard.go
@@ -1019,8 +1019,9 @@ func (b *BootGuard) CreateIBBSegments(seElement uint8, flags uint16, imagepath s
 		return err
 	}
 	defer func() {
-		err := image.Close()
-		log.Warnf("failed to close the file: %v\n", err)
+		if err := image.Close(); err != nil {
+			log.Warnf("failed to close the file: %v\n", err)
+		}
 	}()
 	stat, err := image.Stat()
 	if err != nil {

--- a/pkg/provisioning/bootguard/tools.go
+++ b/pkg/provisioning/bootguard/tools.go
@@ -105,8 +105,9 @@ func StitchFITEntries(biosFilename string, acm, bpm, km []byte) error {
 		return err
 	}
 	defer func() {
-		err := file.Close()
-		fmt.Printf("warning: failed to close the file: %v\n", err)
+		if err := file.Close(); err != nil {
+			fmt.Printf("warning: failed to close the file: %v\n", err)
+		}
 	}()
 	for _, entry := range fitEntries {
 		switch entry := entry.(type) {

--- a/pkg/provisioning/bootguard/tools.go
+++ b/pkg/provisioning/bootguard/tools.go
@@ -104,7 +104,10 @@ func StitchFITEntries(biosFilename string, acm, bpm, km []byte) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() {
+		err := file.Close()
+		fmt.Printf("warning: failed to close the file: %v\n", err)
+	}()
 	for _, entry := range fitEntries {
 		switch entry := entry.(type) {
 		case *fit.EntryBootPolicyManifestRecord:

--- a/pkg/registers/msr.go
+++ b/pkg/registers/msr.go
@@ -25,8 +25,9 @@ func readMSRFromCpu(msr int64, cpu int) (uint64, error) {
 		return 0, fmt.Errorf("MSR: Selected core %d doesn't exist (%w)", cpu, err)
 	}
 	defer func() {
-		err := msrCtx.Close()
-		fmt.Printf("warning: failed to close the file: %v\n", err)
+		if err := msrCtx.Close(); err != nil {
+			fmt.Printf("warning: failed to close the file: %v\n", err)
+		}
 	}()
 
 	return msrCtx.Read(msr)

--- a/pkg/registers/msr.go
+++ b/pkg/registers/msr.go
@@ -5,6 +5,7 @@ import (
 	"runtime"
 
 	"github.com/9elements/converged-security-suite/v2/pkg/errors"
+	// TODO: replace with go-msr
 	"github.com/fearful-symmetry/gomsr"
 )
 
@@ -23,7 +24,10 @@ func readMSRFromCpu(msr int64, cpu int) (uint64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("MSR: Selected core %d doesn't exist (%w)", cpu, err)
 	}
-	defer msrCtx.Close()
+	defer func() {
+		err := msrCtx.Close()
+		fmt.Printf("warning: failed to close the file: %v\n", err)
+	}()
 
 	return msrCtx.Read(msr)
 }

--- a/pkg/test/cpu.go
+++ b/pkg/test/cpu.go
@@ -240,7 +240,7 @@ func Ia32FeatureCtrl(txtAPI hwapi.LowLevelHardwareInterfaces, p *PreSet) (bool, 
 
 // SMXIsEnabled not implemented
 func SMXIsEnabled(txtAPI hwapi.LowLevelHardwareInterfaces, p *PreSet) (bool, error, error) {
-	return false, nil, fmt.Errorf("Unimplemented: no comment")
+	return false, nil, fmt.Errorf("unimplemented: no comment")
 }
 
 // Check CR4 wherther SMXE is set

--- a/pkg/test/test_preset.go
+++ b/pkg/test/test_preset.go
@@ -39,32 +39,32 @@ func ParsePreSet(filepath string) (*PreSet, error) {
 	if err != nil {
 		return nil, err
 	}
-	if config.TPM == "1.2" {
+	switch config.TPM {
+	case "1.2":
 		preset.TPM = hwapi.TPMVersion12
-	} else if config.TPM == "2.0" {
+	case "2.0":
 		preset.TPM = hwapi.TPMVersion20
-	} else {
-		return nil, fmt.Errorf("couldn't parse TPM option: %s", config.TPM)
 	}
-	if config.TXTMode == "auto" {
+	switch config.TXTMode {
+	case "auto":
 		preset.TXTMode = tools.AutoPromotion
-	} else if config.TXTMode == "signed" {
+	case "signed":
 		preset.TXTMode = tools.SignedPolicy
-	} else {
+	default:
 		return nil, fmt.Errorf("couldn't parse TXT mode option: %s", config.TXTMode)
 	}
-	if config.LCP2Hash == "SHA1" {
+	switch config.LCP2Hash {
+	case "SHA1":
 		preset.LCPHash = tpm2.AlgSHA1
-	} else if config.LCP2Hash == "SHA256" {
+	case "SHA256":
 		preset.LCPHash = tpm2.AlgSHA256
-	} else if config.LCP2Hash == "SHA384" {
+	case "SHA384":
 		preset.LCPHash = tpm2.AlgSHA384
-	} else if config.LCP2Hash == "SM3" {
+	case "SM3":
 		// SM3 is not implemented
-		// config.LCPHash = tpm2.AlgSM3
-	} else if config.LCP2Hash == "NULL" {
+	case "NULL":
 		preset.LCPHash = tpm2.AlgNull
-	} else {
+	default:
 		return nil, fmt.Errorf("couldn't parse LCP hash option: %s", config.LCP2Hash)
 	}
 	return &preset, nil

--- a/pkg/test/tpm.go
+++ b/pkg/test/tpm.go
@@ -200,8 +200,9 @@ func TPMConnect(txtAPI hwapi.LowLevelHardwareInterfaces, p *PreSet) (bool, error
 	tpmCon, err := txtAPI.NewTPM()
 	if err == nil && tpmCon != nil {
 		defer func() {
-			err := tpmCon.Close()
-			fmt.Printf("warning: failed to close the socket: %v\n", err)
+			if err := tpmCon.Close(); err != nil {
+				fmt.Printf("warning: failed to close the socket: %v\n", err)
+			}
 		}()
 		return true, nil, nil
 	}
@@ -215,8 +216,9 @@ func TPMIsPresent(txtAPI hwapi.LowLevelHardwareInterfaces, p *PreSet) (bool, err
 		return false, fmt.Errorf("no TPM connection"), nil
 	}
 	defer func() {
-		err := tpmCon.Close()
-		fmt.Printf("warning: failed to close the socket: %v\n", err)
+		if err := tpmCon.Close(); err != nil {
+			fmt.Printf("warning: failed to close the socket: %v\n", err)
+		}
 	}()
 	if tpmCon.Version == p.TPM {
 		return true, nil, nil
@@ -231,8 +233,9 @@ func TPMNVRAMIsLocked(txtAPI hwapi.LowLevelHardwareInterfaces, p *PreSet) (bool,
 		return false, fmt.Errorf("no TPM connection"), nil
 	}
 	defer func() {
-		err := tpmCon.Close()
-		fmt.Printf("warning: failed to close the socket: %v\n", err)
+		if err := tpmCon.Close(); err != nil {
+			fmt.Printf("warning: failed to close the socket: %v\n", err)
+		}
 	}()
 	res, err := txtAPI.NVLocked(tpmCon)
 	return res, err, nil
@@ -251,8 +254,9 @@ func PSIndexConfig(txtAPI hwapi.LowLevelHardwareInterfaces, p *PreSet) (bool, er
 		return false, fmt.Errorf("no TPM connection"), nil
 	}
 	defer func() {
-		err := tpmCon.Close()
-		fmt.Printf("warning: failed to close the socket: %v\n", err)
+		if err := tpmCon.Close(); err != nil {
+			fmt.Printf("warning: failed to close the socket: %v\n", err)
+		}
 	}()
 	switch tpmCon.Version {
 	case hwapi.TPMVersion12:
@@ -360,8 +364,9 @@ func AUXIndexConfig(txtAPI hwapi.LowLevelHardwareInterfaces, p *PreSet) (bool, e
 		return false, fmt.Errorf("no TPM connection"), nil
 	}
 	defer func() {
-		err := tpmCon.Close()
-		fmt.Printf("warning: failed to close the socket: %v\n", err)
+		if err := tpmCon.Close(); err != nil {
+			fmt.Printf("warning: failed to close the socket: %v\n", err)
+		}
 	}()
 	switch tpmCon.Version {
 	case hwapi.TPMVersion12:
@@ -463,8 +468,9 @@ func AUXTPM2IndexCheckHash(txtAPI hwapi.LowLevelHardwareInterfaces, p *PreSet) (
 		return false, fmt.Errorf("no TPM connection"), nil
 	}
 	defer func() {
-		err := tpmCon.Close()
-		fmt.Printf("warning: failed to close the socket: %v\n", err)
+		if err := tpmCon.Close(); err != nil {
+			fmt.Printf("warning: failed to close the socket: %v\n", err)
+		}
 	}()
 	switch tpmCon.Version {
 	case hwapi.TPMVersion12:
@@ -527,8 +533,9 @@ func POIndexConfig(txtAPI hwapi.LowLevelHardwareInterfaces, p *PreSet) (bool, er
 		return false, fmt.Errorf("no TPM connection"), nil
 	}
 	defer func() {
-		err := tpmCon.Close()
-		fmt.Printf("warning: failed to close the socket: %v\n", err)
+		if err := tpmCon.Close(); err != nil {
+			fmt.Printf("warning: failed to close the socket: %v\n", err)
+		}
 	}()
 	switch tpmCon.Version {
 	case hwapi.TPMVersion12:
@@ -669,8 +676,9 @@ func POIndexHasValidLCP(txtAPI hwapi.LowLevelHardwareInterfaces, p *PreSet) (boo
 		return false, fmt.Errorf("no TPM connection"), nil
 	}
 	defer func() {
-		err := tpmCon.Close()
-		fmt.Printf("warning: failed to close the socket: %v\n", err)
+		if err := tpmCon.Close(); err != nil {
+			fmt.Printf("warning: failed to close the socket: %v\n", err)
+		}
 	}()
 	switch tpmCon.Version {
 	case hwapi.TPMVersion12:
@@ -792,8 +800,9 @@ func PCR0IsSet(txtAPI hwapi.LowLevelHardwareInterfaces, p *PreSet) (bool, error,
 		return false, fmt.Errorf("no TPM connection"), nil
 	}
 	defer func() {
-		err := tpmCon.Close()
-		fmt.Printf("warning: failed to close the socket: %v\n", err)
+		if err := tpmCon.Close(); err != nil {
+			fmt.Printf("warning: failed to close the socket: %v\n", err)
+		}
 	}()
 	pcr, err := txtAPI.ReadPCR(tpmCon, 0)
 	if err != nil {
@@ -817,8 +826,9 @@ func readPSLCPPolicy(txtAPI hwapi.LowLevelHardwareInterfaces) (*tools.LCPPolicy,
 		return nil, nil, fmt.Errorf("no TPM connection")
 	}
 	defer func() {
-		err := tpmCon.Close()
-		fmt.Printf("warning: failed to close the socket: %v\n", err)
+		if err := tpmCon.Close(); err != nil {
+			fmt.Printf("warning: failed to close the socket: %v\n", err)
+		}
 	}()
 	switch tpmCon.Version {
 	case hwapi.TPMVersion12:

--- a/pkg/test/tpm.go
+++ b/pkg/test/tpm.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/9elements/converged-security-suite/v2/pkg/tools"
 	"github.com/9elements/go-linux-lowlevel-hw/pkg/hwapi"
-	tpm1 "github.com/google/go-tpm/tpm"
 	"github.com/google/go-tpm/legacy/tpm2"
+	tpm1 "github.com/google/go-tpm/tpm"
 )
 
 // nolint
@@ -199,7 +199,10 @@ var (
 func TPMConnect(txtAPI hwapi.LowLevelHardwareInterfaces, p *PreSet) (bool, error, error) {
 	tpmCon, err := txtAPI.NewTPM()
 	if err == nil && tpmCon != nil {
-		defer tpmCon.Close()
+		defer func() {
+			err := tpmCon.Close()
+			fmt.Printf("warning: failed to close the socket: %v\n", err)
+		}()
 		return true, nil, nil
 	}
 	return false, nil, err
@@ -211,7 +214,10 @@ func TPMIsPresent(txtAPI hwapi.LowLevelHardwareInterfaces, p *PreSet) (bool, err
 	if err != nil {
 		return false, fmt.Errorf("no TPM connection"), nil
 	}
-	defer tpmCon.Close()
+	defer func() {
+		err := tpmCon.Close()
+		fmt.Printf("warning: failed to close the socket: %v\n", err)
+	}()
 	if tpmCon.Version == p.TPM {
 		return true, nil, nil
 	}
@@ -224,7 +230,10 @@ func TPMNVRAMIsLocked(txtAPI hwapi.LowLevelHardwareInterfaces, p *PreSet) (bool,
 	if err != nil {
 		return false, fmt.Errorf("no TPM connection"), nil
 	}
-	defer tpmCon.Close()
+	defer func() {
+		err := tpmCon.Close()
+		fmt.Printf("warning: failed to close the socket: %v\n", err)
+	}()
 	res, err := txtAPI.NVLocked(tpmCon)
 	return res, err, nil
 }
@@ -241,7 +250,10 @@ func PSIndexConfig(txtAPI hwapi.LowLevelHardwareInterfaces, p *PreSet) (bool, er
 	if err != nil {
 		return false, fmt.Errorf("no TPM connection"), nil
 	}
-	defer tpmCon.Close()
+	defer func() {
+		err := tpmCon.Close()
+		fmt.Printf("warning: failed to close the socket: %v\n", err)
+	}()
 	switch tpmCon.Version {
 	case hwapi.TPMVersion12:
 		raw, err = txtAPI.ReadNVPublic(tpmCon, tpm12PSIndex)
@@ -347,7 +359,10 @@ func AUXIndexConfig(txtAPI hwapi.LowLevelHardwareInterfaces, p *PreSet) (bool, e
 	if err != nil {
 		return false, fmt.Errorf("no TPM connection"), nil
 	}
-	defer tpmCon.Close()
+	defer func() {
+		err := tpmCon.Close()
+		fmt.Printf("warning: failed to close the socket: %v\n", err)
+	}()
 	switch tpmCon.Version {
 	case hwapi.TPMVersion12:
 		raw, err = txtAPI.ReadNVPublic(tpmCon, tpm12AUXIndex)
@@ -447,7 +462,10 @@ func AUXTPM2IndexCheckHash(txtAPI hwapi.LowLevelHardwareInterfaces, p *PreSet) (
 	if err != nil {
 		return false, fmt.Errorf("no TPM connection"), nil
 	}
-	defer tpmCon.Close()
+	defer func() {
+		err := tpmCon.Close()
+		fmt.Printf("warning: failed to close the socket: %v\n", err)
+	}()
 	switch tpmCon.Version {
 	case hwapi.TPMVersion12:
 		return false, fmt.Errorf("only valid for TPM 2.0"), nil
@@ -508,7 +526,10 @@ func POIndexConfig(txtAPI hwapi.LowLevelHardwareInterfaces, p *PreSet) (bool, er
 	if err != nil {
 		return false, fmt.Errorf("no TPM connection"), nil
 	}
-	defer tpmCon.Close()
+	defer func() {
+		err := tpmCon.Close()
+		fmt.Printf("warning: failed to close the socket: %v\n", err)
+	}()
 	switch tpmCon.Version {
 	case hwapi.TPMVersion12:
 		raw, err = txtAPI.ReadNVPublic(tpmCon, tpm12POIndex)
@@ -647,7 +668,10 @@ func POIndexHasValidLCP(txtAPI hwapi.LowLevelHardwareInterfaces, p *PreSet) (boo
 	if err != nil {
 		return false, fmt.Errorf("no TPM connection"), nil
 	}
-	defer tpmCon.Close()
+	defer func() {
+		err := tpmCon.Close()
+		fmt.Printf("warning: failed to close the socket: %v\n", err)
+	}()
 	switch tpmCon.Version {
 	case hwapi.TPMVersion12:
 		_, err := txtAPI.ReadNVPublic(tpmCon, tpm12POIndex)
@@ -767,7 +791,10 @@ func PCR0IsSet(txtAPI hwapi.LowLevelHardwareInterfaces, p *PreSet) (bool, error,
 	if err != nil {
 		return false, fmt.Errorf("no TPM connection"), nil
 	}
-	defer tpmCon.Close()
+	defer func() {
+		err := tpmCon.Close()
+		fmt.Printf("warning: failed to close the socket: %v\n", err)
+	}()
 	pcr, err := txtAPI.ReadPCR(tpmCon, 0)
 	if err != nil {
 		return false, nil, err
@@ -789,7 +816,10 @@ func readPSLCPPolicy(txtAPI hwapi.LowLevelHardwareInterfaces) (*tools.LCPPolicy,
 	if err != nil {
 		return nil, nil, fmt.Errorf("no TPM connection")
 	}
-	defer tpmCon.Close()
+	defer func() {
+		err := tpmCon.Close()
+		fmt.Printf("warning: failed to close the socket: %v\n", err)
+	}()
 	switch tpmCon.Version {
 	case hwapi.TPMVersion12:
 		data, err := txtAPI.NVReadValue(tpmCon, tpm12PSIndex, "", tpm12PSIndexSize, 0)

--- a/pkg/tools/lcp.go
+++ b/pkg/tools/lcp.go
@@ -25,11 +25,12 @@ var HashAlgMap = map[crypto.Hash]tpm2.Algorithm{
 type LCPPolicyType uint8
 
 func (pt LCPPolicyType) String() string {
-	if pt == 1 {
+	switch pt {
+	case 1:
 		return string("Any")
-	} else if pt == 0 {
+	case 0:
 		return string("List")
-	} else {
+	default:
 		return string("Unknown")
 	}
 }

--- a/pkg/tpm/read_pcr_from_tpm.go
+++ b/pkg/tpm/read_pcr_from_tpm.go
@@ -7,8 +7,8 @@ import (
 	"github.com/9elements/converged-security-suite/v2/pkg/bootflow/subsystems/trustchains/tpm/pcr"
 	"github.com/9elements/converged-security-suite/v2/pkg/errors"
 	"github.com/9elements/go-linux-lowlevel-hw/pkg/hwapi"
-	tpm1 "github.com/google/go-tpm/tpm"
 	"github.com/google/go-tpm/legacy/tpm2"
+	tpm1 "github.com/google/go-tpm/tpm"
 	"github.com/marcoguerri/go-tpm-tcti/abrmd"
 )
 
@@ -33,7 +33,10 @@ func ReadPCRFromTPM(pcrIndex pcr.ID, alg tpm2.Algorithm) ([]byte, error) {
 	// Try abrmd first, if failure then try /dev/tpm{rm,}.
 	abrmdClient, err := abrmd.NewBroker()
 	if err == nil {
-		defer abrmdClient.Close()
+		defer func() {
+			err := abrmdClient.Close()
+			fmt.Printf("warning: failed to close the connection: %v\n", err)
+		}()
 		// abrmd is part of TPM2 tools, therefore we support on TPM2.0 here.
 		// If we have TPM1.2 then abrmdClient won't initialize.
 		pcrValue, err := tpm2.ReadPCR(abrmdClient, int(pcrIndex), alg)
@@ -51,7 +54,10 @@ func ReadPCRFromTPM(pcrIndex pcr.ID, alg tpm2.Algorithm) ([]byte, error) {
 		_ = mErr.Add(fmt.Errorf("unable to open TPM: %w", err))
 		return nil, mErr.ReturnValue()
 	}
-	defer tpm.Close()
+	defer func() {
+		err := tpm.Close()
+		fmt.Printf("warning: failed to close the socket: %v\n", err)
+	}()
 
 	// There's method tpm.ReadPCR, but we cannot use it because it does
 	// not allow to pick the hashing algorithm.

--- a/pkg/tpm/read_pcr_from_tpm.go
+++ b/pkg/tpm/read_pcr_from_tpm.go
@@ -34,8 +34,9 @@ func ReadPCRFromTPM(pcrIndex pcr.ID, alg tpm2.Algorithm) ([]byte, error) {
 	abrmdClient, err := abrmd.NewBroker()
 	if err == nil {
 		defer func() {
-			err := abrmdClient.Close()
-			fmt.Printf("warning: failed to close the connection: %v\n", err)
+			if err := abrmdClient.Close(); err != nil {
+				fmt.Printf("warning: failed to close the connection: %v\n", err)
+			}
 		}()
 		// abrmd is part of TPM2 tools, therefore we support on TPM2.0 here.
 		// If we have TPM1.2 then abrmdClient won't initialize.
@@ -55,8 +56,9 @@ func ReadPCRFromTPM(pcrIndex pcr.ID, alg tpm2.Algorithm) ([]byte, error) {
 		return nil, mErr.ReturnValue()
 	}
 	defer func() {
-		err := tpm.Close()
-		fmt.Printf("warning: failed to close the socket: %v\n", err)
+		if err := tpm.Close(); err != nil {
+			fmt.Printf("warning: failed to close the socket: %v\n", err)
+		}
 	}()
 
 	// There's method tpm.ReadPCR, but we cannot use it because it does

--- a/pkg/tpmeventlog/replay.go
+++ b/pkg/tpmeventlog/replay.go
@@ -90,8 +90,8 @@ func Replay(eventLog *TPMEventLog, pcrIndex pcr.ID, hashAlgo TPMAlgorithm, logOu
 
 	// Replay the log
 	for _, event := range events {
-		switch {
-		case event.Type == EV_NO_ACTION:
+		switch event.Type {
+		case EV_NO_ACTION:
 			if len(result) != 0 {
 				return nil, ErrUnexpectedEventType{Event: *event, Reason: "already initialized"}
 			}

--- a/pkg/uefi/uefi.go
+++ b/pkg/uefi/uefi.go
@@ -73,7 +73,7 @@ func ParseUEFIFirmwareBytes(imageBytes []byte) (*UEFI, error) {
 	if err != nil {
 		return nil, fmt.Errorf(`unable to parse the UEFI structure of the image: %w`, err)
 	}
-	uefi.Range.Length = uint64(len(uefi.Buf()))
+	uefi.Length = uint64(len(uefi.Buf()))
 
 	return uefi, nil
 }


### PR DESCRIPTION
Currently liner check fails with:
```
35 issues:
  * errcheck: 10
  * staticcheck: 25
```
Note: the CI does not check `cmd/`, I covered the errcheck errors that can be seen by running the linter locally over `cmd/`, all staticcheck error are not covered yet. I think it would make sense to modify the workflow to also go over `cmd/`, but that's something for the future (as it requires quite a lot of fixing for the linter to be "green")