### PR TITLE
ci: add round trip validation job

### DIFF
--- a/.github/scripts/extract_km_pubkey.sh
+++ b/.github/scripts/extract_km_pubkey.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# For reference:
+# extract_km_pubkey.sh <config.json> <km_manifest_key> <output.pem>
+
+CONFIG=$1
+MANIFEST_KEY=$2
+OUTPUT_PEM=$3
+
+jq -r '."'"$MANIFEST_KEY"'".kmKeySignature.ksKey.keyData' "$CONFIG" | base64 -d > /tmp/keydata.bin
+
+EXPONENT_HEX=$(dd if=/tmp/keydata.bin bs=1 count=4 2>/dev/null | od -An -tx1 | tr -d ' \n' | fold -w2 | tac | tr -d '\n')
+MODULUS_HEX=$(dd if=/tmp/keydata.bin bs=1 skip=4 2>/dev/null | od -An -tx1 | tr -d ' \n' | fold -w2 | tac | tr -d '\n')
+
+cat > /tmp/rsa_key.asn1 << EOF
+asn1=SEQUENCE:rsa_key
+[rsa_key]
+n=INTEGER:0x${MODULUS_HEX}
+e=INTEGER:0x${EXPONENT_HEX}
+EOF
+
+openssl asn1parse -genconf /tmp/rsa_key.asn1 -out /tmp/rsa_key.der -noout
+openssl rsa -in /tmp/rsa_key.der \
+  -inform DER \
+  -RSAPublicKey_in \
+  -pubout \
+  -out "$OUTPUT_PEM"
+
+rm -f /tmp/keydata.bin /tmp/rsa_key.asn1 /tmp/rsa_key.der

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,22 +140,33 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
-              uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+              uses: actions/checkout@v6.0.1
 
             - name: Install dependencies
               run: sudo apt update & sudo apt install openssl
 
+            - name: Cache firmware images
+              id: cache-firmware
+              uses: actions/cache@v4
+              with:
+                path: |
+                  firmware10.bin
+                  firmware20.bin
+                key: firmware-imgs
+
             - name: Download FW with BtG 1.0
+              if: steps.cache-firmware.outputs.cache-hit != 'true'
               run: |
                 wget "https://downloads.hpe.com/pub/softlib2/software1/pubfw-uefi/p736852486/v283550/U30_3.66_04_01_2026.signed.flash"
                 mv U30_3.66_04_01_2026.signed.flash firmware10.bin
             - name: Download FW with CBnT 2.0
+              if: steps.cache-firmware.outputs.cache-hit != 'true'
               run: |
                 wget "https://download.asrock.com/BIOS/4677/W790%20WS(9.01)ROM.zip"
                 unzip W790\ WS\(9.01\)ROM.zip
                 mv W790-WS_9.01.ROM firmware20.bin
             - name: Download Artifacts
-              uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+              uses: actions/download-artifact@v7.0.0
               with:
                 name: artifacts-amd64
                 path: ./artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,3 +135,97 @@ jobs:
                 --pbet=12 --ibbflags=1 --mchbar=123456 --vdtbar=120000 --dmabase0=130000 \
                 --dmasize0=2048 --entrypoint=140000 --ibbhash=SHA256 config.json
                 cat ./config.json | jq
+    RoundTripValidation:
+        needs: build
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+            - name: Install dependencies
+              run: sudo apt update & sudo apt install openssl
+
+            - name: Download FW with BtG 1.0
+              run: |
+                wget "https://downloads.hpe.com/pub/softlib2/software1/pubfw-uefi/p736852486/v283550/U30_3.66_04_01_2026.signed.flash"
+                mv U30_3.66_04_01_2026.signed.flash firmware10.bin
+            - name: Download FW with CBnT 2.0
+              run: |
+                wget "https://download.asrock.com/BIOS/4677/W790%20WS(9.01)ROM.zip"
+                unzip W790\ WS\(9.01\)ROM.zip
+                mv W790-WS_9.01.ROM firmware20.bin
+            - name: Download Artifacts
+              uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+              with:
+                name: artifacts-amd64
+                path: ./artifacts
+
+            - name: Make artifacts executable
+              run: chmod +x ./artifacts/*
+
+            - name: Read 1.0 config
+              run: |
+                ./artifacts/bg-prov read-config config10.json ./firmware10.bin
+                ./artifacts/bg-prov bpm-export ./firmware10.bin bpm10.bin
+                ./artifacts/bg-prov km-export ./firmware10.bin km10.bin
+                sha256sum km10.bin > checksums
+                sha256sum bpm10.bin >> checksums
+                sha256sum km10.bin
+                sha256sum bpm10.bin
+                rm km10.bin bpm10.bin
+            - name: Extract pubkey from KM 1.0
+              run: |
+                KEY_DATA_B64=$(jq -r '."v1-keymanifest".kmKeySignature.ksKey.keyData' config10.json)
+                echo "$KEY_DATA_B64" | base64 -d > /tmp/keydata.bin
+                EXPONENT_HEX=$(dd if=/tmp/keydata.bin bs=1 count=4 2>/dev/null | od -An -tx1 | tr -d ' \n' | fold -w2 | tac | tr -d '\n')
+                MODULUS_HEX=$(dd if=/tmp/keydata.bin bs=1 skip=4 2>/dev/null | od -An -tx1 | tr -d ' \n' | fold -w2 | tac | tr -d '\n')
+                cat > /tmp/rsa_key.asn1 << EOF
+                asn1=SEQUENCE:rsa_key
+                [rsa_key]
+                n=INTEGER:0x${MODULUS_HEX}
+                e=INTEGER:0x${EXPONENT_HEX}
+                EOF
+                openssl asn1parse -genconf /tmp/rsa_key.asn1 -out /tmp/rsa_key.der -noout
+                openssl rsa -in /tmp/rsa_key.der \
+                  -inform DER \
+                  -RSAPublicKey_in \
+                  -pubout \
+                  -out km_pub10.pem
+                rm -f /tmp/keydata.bin /tmp/rsa_key.asn1 /tmp/rsa_key.der
+            - name: Generate 1.0 from config
+              run: |
+                ./artifacts/bg-prov bpm-gen-v-1 --config=config10.json bpm10.bin ./firmware10.bin
+                ./artifacts/bg-prov km-gen-v-1 --config=config10.json km10.bin km_pub10.pem
+                sha256sum -c checksums
+            - name: Read 2.0 config
+              run: |
+                ./artifacts/bg-prov read-config config20.json ./firmware20.bin
+                ./artifacts/bg-prov bpm-export ./firmware20.bin bpm20.bin
+                ./artifacts/bg-prov km-export ./firmware20.bin km20.bin
+                sha256sum km20.bin > checksums
+                sha256sum bpm20.bin >> checksums
+                rm km20.bin bpm20.bin
+            - name: Extract pubkey from KM 2.0
+              run: |
+                KEY_DATA_B64=$(jq -r '."v2-keymanifest".kmKeySignature.ksKey.keyData' config20.json)
+                echo "$KEY_DATA_B64" | base64 -d > /tmp/keydata.bin
+                EXPONENT_HEX=$(dd if=/tmp/keydata.bin bs=1 count=4 2>/dev/null | od -An -tx1 | tr -d ' \n' | fold -w2 | tac | tr -d '\n')
+                MODULUS_HEX=$(dd if=/tmp/keydata.bin bs=1 skip=4 2>/dev/null | od -An -tx1 | tr -d ' \n' | fold -w2 | tac | tr -d '\n')
+                cat > /tmp/rsa_key.asn1 << EOF
+                asn1=SEQUENCE:rsa_key
+                [rsa_key]
+                n=INTEGER:0x${MODULUS_HEX}
+                e=INTEGER:0x${EXPONENT_HEX}
+                EOF
+                openssl asn1parse -genconf /tmp/rsa_key.asn1 -out /tmp/rsa_key.der -noout
+                openssl rsa -in /tmp/rsa_key.der \
+                  -inform DER \
+                  -RSAPublicKey_in \
+                  -pubout \
+                  -out km_pub20.pem
+                rm -f /tmp/keydata.bin /tmp/rsa_key.asn1 /tmp/rsa_key.der
+            - name: Generate 2.0 from config
+              run: |
+                ./artifacts/bg-prov bpm-gen-v-2 --config=config20.json bpm20.bin ./firmware20.bin
+                ./artifacts/bg-prov km-gen-v-2 --config=config20.json km20.bin km_pub20.pem
+                sha256sum -c checksums

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,33 +181,17 @@ jobs:
                 ./artifacts/bg-prov km-export ./firmware10.bin km10.bin
                 sha256sum km10.bin > checksums
                 sha256sum bpm10.bin >> checksums
-                sha256sum km10.bin
-                sha256sum bpm10.bin
                 rm km10.bin bpm10.bin
+
             - name: Extract pubkey from KM 1.0
-              run: |
-                KEY_DATA_B64=$(jq -r '."v1-keymanifest".kmKeySignature.ksKey.keyData' config10.json)
-                echo "$KEY_DATA_B64" | base64 -d > /tmp/keydata.bin
-                EXPONENT_HEX=$(dd if=/tmp/keydata.bin bs=1 count=4 2>/dev/null | od -An -tx1 | tr -d ' \n' | fold -w2 | tac | tr -d '\n')
-                MODULUS_HEX=$(dd if=/tmp/keydata.bin bs=1 skip=4 2>/dev/null | od -An -tx1 | tr -d ' \n' | fold -w2 | tac | tr -d '\n')
-                cat > /tmp/rsa_key.asn1 << EOF
-                asn1=SEQUENCE:rsa_key
-                [rsa_key]
-                n=INTEGER:0x${MODULUS_HEX}
-                e=INTEGER:0x${EXPONENT_HEX}
-                EOF
-                openssl asn1parse -genconf /tmp/rsa_key.asn1 -out /tmp/rsa_key.der -noout
-                openssl rsa -in /tmp/rsa_key.der \
-                  -inform DER \
-                  -RSAPublicKey_in \
-                  -pubout \
-                  -out km_pub10.pem
-                rm -f /tmp/keydata.bin /tmp/rsa_key.asn1 /tmp/rsa_key.der
+              run: .github/scripts/extract_km_pubkey.sh config10.json v1-keymanifest km_pub10.pem
+
             - name: Generate 1.0 from config
               run: |
                 ./artifacts/bg-prov bpm-gen-v-1 --config=config10.json bpm10.bin ./firmware10.bin
                 ./artifacts/bg-prov km-gen-v-1 --config=config10.json km10.bin km_pub10.pem
                 sha256sum -c checksums
+
             - name: Read 2.0 config
               run: |
                 ./artifacts/bg-prov read-config config20.json ./firmware20.bin
@@ -216,25 +200,10 @@ jobs:
                 sha256sum km20.bin > checksums
                 sha256sum bpm20.bin >> checksums
                 rm km20.bin bpm20.bin
+
             - name: Extract pubkey from KM 2.0
-              run: |
-                KEY_DATA_B64=$(jq -r '."v2-keymanifest".kmKeySignature.ksKey.keyData' config20.json)
-                echo "$KEY_DATA_B64" | base64 -d > /tmp/keydata.bin
-                EXPONENT_HEX=$(dd if=/tmp/keydata.bin bs=1 count=4 2>/dev/null | od -An -tx1 | tr -d ' \n' | fold -w2 | tac | tr -d '\n')
-                MODULUS_HEX=$(dd if=/tmp/keydata.bin bs=1 skip=4 2>/dev/null | od -An -tx1 | tr -d ' \n' | fold -w2 | tac | tr -d '\n')
-                cat > /tmp/rsa_key.asn1 << EOF
-                asn1=SEQUENCE:rsa_key
-                [rsa_key]
-                n=INTEGER:0x${MODULUS_HEX}
-                e=INTEGER:0x${EXPONENT_HEX}
-                EOF
-                openssl asn1parse -genconf /tmp/rsa_key.asn1 -out /tmp/rsa_key.der -noout
-                openssl rsa -in /tmp/rsa_key.der \
-                  -inform DER \
-                  -RSAPublicKey_in \
-                  -pubout \
-                  -out km_pub20.pem
-                rm -f /tmp/keydata.bin /tmp/rsa_key.asn1 /tmp/rsa_key.der
+              run: .github/scripts/extract_km_pubkey.sh config20.json v2-keymanifest km_pub20.pem
+
             - name: Generate 2.0 from config
               run: |
                 ./artifacts/bg-prov bpm-gen-v-2 --config=config20.json bpm20.bin ./firmware20.bin

--- a/pkg/provisioning/bootguard/bootguard.go
+++ b/pkg/provisioning/bootguard/bootguard.go
@@ -821,86 +821,53 @@ func (b *BootGuard) GetBPMPubHash(pubkey crypto.PublicKey, hashAlgo string) erro
 }
 
 func (b *BootGuard) GetIBBsDigest(image []byte, hashAlgo string) (digest []byte, err error) {
+	var ibbs []bootpolicy.IBBSegment
 	switch b.Version {
 	case cbnt.Version10:
-		hashAlg, err := cbnt.GetAlgFromString(hashAlgo)
-		if err != nil {
-			return nil, err
-		}
-		hash, err := hashAlg.Hash()
-		if err != nil {
-			return nil, err
-		}
-		ibbs := b.VData.BGbpm.SE[0].IBBSegments
-		reader := bytes.NewReader(image)
-		ibbSegments := make([][]byte, len(ibbs))
-		for idx, ibb := range ibbs {
-			if ibb.Flags&(1<<0) != 0 {
-				continue
-			}
-			addr, err := tools.CalcImageOffset(image, uint64(ibb.Base))
-			if err != nil {
-				return nil, fmt.Errorf("unable to calculate the offset: %w", err)
-			}
-			_, err = reader.Seek(int64(addr), io.SeekStart)
-			if err != nil {
-				return nil, fmt.Errorf("got error from Seek: %w", err)
-			}
-			size := uint64(ibb.Size)
-			ibbSegments[idx] = make([]byte, size)
-			_, err = reader.Read(ibbSegments[idx])
-			if err != nil {
-				return nil, fmt.Errorf("unable to read the segment: %w", err)
-			}
-		}
-		for _, segment := range ibbSegments {
-			_, err = hash.Write(segment)
-			if err != nil {
-				return nil, err
-			}
-		}
-		digest = hash.Sum(nil)
+		ibbs = b.VData.BGbpm.SE[0].IBBSegments
 	case cbnt.Version20, cbnt.Version21:
-		hashAlg, err := cbnt.GetAlgFromString(hashAlgo)
-		if err != nil {
-			return nil, err
-		}
-		hash, err := hashAlg.Hash()
-		if err != nil {
-			return nil, err
-		}
-		ibbs := b.VData.CBNTbpm.SE[0].IBBSegments
-		reader := bytes.NewReader(image)
-		ibbSegments := make([][]byte, len(ibbs))
-		for idx, ibb := range ibbs {
-			if ibb.Flags&(1<<0) != 0 {
-				continue
-			}
-			addr, err := tools.CalcImageOffset(image, uint64(ibb.Base))
-			if err != nil {
-				return nil, fmt.Errorf("unable to calculate the offset: %w", err)
-			}
-			_, err = reader.Seek(int64(addr), io.SeekStart)
-			if err != nil {
-				return nil, fmt.Errorf("got error from Seek: %w", err)
-			}
-			size := uint64(ibb.Size)
-			ibbSegments[idx] = make([]byte, size)
-			_, err = reader.Read(ibbSegments[idx])
-			if err != nil {
-				return nil, fmt.Errorf("unable to read the segment: %w", err)
-			}
-		}
-		for _, segment := range ibbSegments {
-			_, err = hash.Write(segment)
-			if err != nil {
-				return nil, err
-			}
-		}
-		digest = hash.Sum(nil)
+		ibbs = b.VData.CBNTbpm.SE[0].IBBSegments
 	default:
-		log.Error("can't identify bootguard header")
+		return nil, fmt.Errorf("cannot identify bootguard header")
 	}
+	hashAlg, err := cbnt.GetAlgFromString(hashAlgo)
+	if err != nil {
+		return nil, err
+	}
+	hash, err := hashAlg.Hash()
+	if err != nil {
+		return nil, err
+	}
+	imgSize := uint64(len(image))
+	if ifdSize, ifdErr := bootpolicy.FlashSizeIFD(image); ifdErr == nil && ifdSize > 0 && ifdSize <= imgSize {
+		imgSize = ifdSize
+	}
+
+	reader := bytes.NewReader(image)
+	ibbSegments := make([][]byte, len(ibbs))
+	for idx, ibb := range ibbs {
+		if ibb.Flags&(1<<0) != 0 {
+			continue
+		}
+		addr := bootpolicy.CalculateOffsetFromPhysAddr(uint64(ibb.Base), imgSize)
+		_, err = reader.Seek(int64(addr), io.SeekStart)
+		if err != nil {
+			return nil, fmt.Errorf("got error from Seek: %w", err)
+		}
+		size := uint64(ibb.Size)
+		ibbSegments[idx] = make([]byte, size)
+		_, err = reader.Read(ibbSegments[idx])
+		if err != nil {
+			return nil, fmt.Errorf("unable to read the segment: %w", err)
+		}
+	}
+	for _, segment := range ibbSegments {
+		_, err = hash.Write(segment)
+		if err != nil {
+			return nil, err
+		}
+	}
+	digest = hash.Sum(nil)
 	return digest, nil
 }
 


### PR DESCRIPTION
Add CI job that validates that the binaries exported from a given image are identical to the ones generated based on the config from the same image.

When calculating IBB segments, let the bios flash area size to be taken from IFD on a missmatch between the image length and the bios flash area.